### PR TITLE
Fixed invitations expiring too quickly

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -97,7 +97,7 @@ return [
             'provider' => 'users',
             'table' => 'password_resets',
             'expire' => 60,
-            'invited_expire' => 60*24*7
+            'invites_expire' => 60*24*7
         ],
     ],
 

--- a/resources/views/emails/invite.blade.php
+++ b/resources/views/emails/invite.blade.php
@@ -8,8 +8,16 @@
     </p>
     <div class="row">
         @component('mail::button', ['url'=> config('app.url').'/password/reset/'. $token . '?email='.$recipient->email])
-            @lang('user.accept')
+            Elfogad
         @endcomponent
     </div>
-    <p>@lang('mail.administrators')</p>
+    <p>
+        A regisztrációs link 7 napon belül lejár. Amennyiben addig nem használta, az alábbi gombbal kérhet új linket.
+    </p>
+    <div class="row">
+        @component('mail::button', ['url'=> config('app.url').'/password/reset/'])
+            Új link kérése
+        @endcomponent
+    </div>
+    <p>A rendszergazdák</p>
 @endcomponent


### PR DESCRIPTION
There was a typo in the auth.php config file. As the documentation of the [package](https://github.com/GlaivePro/Invytr) used states, the config values name should be `invites_expire`. It was `invited_expire` before.
Closing #136 