### PR TITLE
Trying to fix mail to staff in FaultController

### DIFF
--- a/app/Http/Controllers/Dormitory/FaultController.php
+++ b/app/Http/Controllers/Dormitory/FaultController.php
@@ -64,7 +64,7 @@ class FaultController extends Controller
     {
         $staffs = Role::firstWhere('name', Role::STAFF)->getUsers();
         foreach ($staffs as $staff) {
-            Mail::to($staff)->queue(new \App\Mail\NewFault($staff->name, $fault, $reopen));
+            Mail::to($staff)->send(new \App\Mail\NewFault($staff->name, $fault, $reopen));
         }
     }
 }


### PR DESCRIPTION
Erika has complained she does not receive mails about faults. I see that the main difference between FaultController's and PrintController's mail management (the latter works) is that FaultController used "queue" instead of "send". May this be a problem? The [documentation](https://laravel.com/docs/9.x/mail) says it's about parallelization. Thank you in advance:)