### PR TITLE
Setting printer size limit to 2 MB

### DIFF
--- a/config/print.php
+++ b/config/print.php
@@ -8,7 +8,7 @@ return [
     ],
 
     // Maximum accepted PDF size in byte.
-    'pdf_size_limit' => env('PRINT_MAX_FILE_SIZE', 5000000),
+    'pdf_size_limit' => env('PRINT_MAX_FILE_SIZE', 2000000),
 
     'printer_name' => env('PRINTER_NAME', 'ujbela'),
 ];


### PR DESCRIPTION
For some reason, it has problems with file sizes above ca. 2 MB. Maybe we should lower the official limit until we find out what the problem is. Thanks in advance:)