### PR TITLE
Displaying the private email of ethics commissioners instead of the university ones

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -104,7 +104,7 @@
                     @if(!$loop->first)|@endif
                     <i>{{$user->name}}</i>
                     @if($user->hasEducationalInformation())
-                    <a href="mailto:{{$user->educationalInformation->email}}"> {{$user->educationalInformation->email}}</a>
+                    <a href="mailto:{{$user->email}}"> {{$user->email}}</a>
                     @endif
                     @if($user->room)
                     ({{$user->room}}. szoba)


### PR DESCRIPTION
There has been a request from a commissioner to do this; and actually it's logical since we've done this with the president too. What do you think?