### PR TITLE
Reviewing the algorithm for calculating workshop balances

### DIFF
--- a/app/Console/Commands/RecalculateWorkshopBalances.php
+++ b/app/Console/Commands/RecalculateWorkshopBalances.php
@@ -42,7 +42,7 @@ class RecalculateWorkshopBalances extends Command
         $semesters = Semester::all()
             ->where('tag', '<=', Semester::current()->tag);
         foreach ($semesters as $semester) {
-            WorkshopBalance::generateBalances($semester->id);
+            WorkshopBalance::generateBalances($semester);
         }
     }
 }

--- a/app/Http/Controllers/Secretariat/UserController.php
+++ b/app/Http/Controllers/Secretariat/UserController.php
@@ -168,7 +168,7 @@ class UserController extends Controller
 
             if($request->has('workshop')) {
                 $user->workshops()->sync($request->input('workshop'));
-                WorkshopBalance::generateBalances(Semester::current()->id);
+                WorkshopBalance::generateBalances(Semester::current());
             }
 
             if($request->has('faculty')) {

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -85,7 +85,9 @@ class EconomicController extends Controller
         $validator->validate();
 
         $payer = User::findOrFail($request->user_id);
-        $payer->payKKTNetreg($request->kkt, $request->netreg);
+        $return_values = $payer->payKKTNetreg($request->kkt, $request->netreg);
+        $kkt = $return_values[0]; $netreg = $return_values[1];
+        $new_internet_expire_date = $return_values[2];
 
         $internet_expiration_message = null;
         if ($new_internet_expire_date !== null) {
@@ -94,7 +96,7 @@ class EconomicController extends Controller
             ]);
         }
 
-        Mail::to($payer)->queue(new \App\Mail\Transactions($payer->name, [$request->kkt, $request->netreg],
+        Mail::to($payer)->queue(new \App\Mail\Transactions($payer->name, [$kkt, $netreg],
                  "Tranzakció létrehozva", $internet_expiration_message));
 
         return redirect()->back()->with('message', __('general.successfully_added'));

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -70,46 +70,46 @@ class EconomicController extends Controller
         ]);
     }
 
-  /**
-    * Pay kkt and netreg to the receiver given.
-    * Also updates workshop balances
-    * and the internet access expiry date.
-    * Returns an array with the two transaction objects
-    * and the new expiry date.
-    *
-    * Used here and in the tests.
-    */
-   public static function payKKTNetregLogic(User $payer, User $receiver, int $kkt_amount, int $netreg_amount): array
-   {
-       // Creating transactions
-       $kkt = Transaction::create([
-           'checkout_id' => Checkout::studentsCouncil()->id,
-           'receiver_id' => $receiver->id,
-           'payer_id' => $payer->id,
-           'semester_id' => Semester::current()->id,
-           'amount' => $kkt_amount,
-           'payment_type_id' => PaymentType::kkt()->id,
-           'comment' => null,
-           'moved_to_checkout' => null,
-       ]);
+    /**
+      * Pay kkt and netreg to the receiver given.
+      * Also updates workshop balances
+      * and the internet access expiry date.
+      * Returns an array with the two transaction objects
+      * and the new expiry date.
+      *
+      * Used here and in the tests.
+      */
+    public static function payKKTNetregLogic(User $payer, User $receiver, int $kkt_amount, int $netreg_amount): array
+    {
+        // Creating transactions
+        $kkt = Transaction::create([
+            'checkout_id' => Checkout::studentsCouncil()->id,
+            'receiver_id' => $receiver->id,
+            'payer_id' => $payer->id,
+            'semester_id' => Semester::current()->id,
+            'amount' => $kkt_amount,
+            'payment_type_id' => PaymentType::kkt()->id,
+            'comment' => null,
+            'moved_to_checkout' => null,
+        ]);
 
-       $netreg = Transaction::create([
-           'checkout_id' => Checkout::admin()->id,
-           'receiver_id' => $receiver->id,
-           'payer_id' => $payer->id,
-           'semester_id' => Semester::current()->id,
-           'amount' => $netreg_amount,
-           'payment_type_id' => PaymentType::netreg()->id,
-           'comment' => null,
-           'moved_to_checkout' => null,
-       ]);
+        $netreg = Transaction::create([
+            'checkout_id' => Checkout::admin()->id,
+            'receiver_id' => $receiver->id,
+            'payer_id' => $payer->id,
+            'semester_id' => Semester::current()->id,
+            'amount' => $netreg_amount,
+            'payment_type_id' => PaymentType::netreg()->id,
+            'comment' => null,
+            'moved_to_checkout' => null,
+        ]);
 
-       WorkshopBalance::generateBalances(Semester::current());
+        WorkshopBalance::generateBalances(Semester::current());
 
-       $new_expiry_date = \App\Http\Controllers\Network\InternetController::extendUsersInternetAccess($payer);
+        $new_expiry_date = \App\Http\Controllers\Network\InternetController::extendUsersInternetAccess($payer);
 
-       return [$kkt, $netreg, $new_expiry_date];
-   }
+        return [$kkt, $netreg, $new_expiry_date];
+    }
 
     /**
      * Pay kkt / netreg.

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -86,7 +86,8 @@ class EconomicController extends Controller
 
         $payer = User::findOrFail($request->user_id);
         $return_values = $payer->payKKTNetreg($request->kkt, $request->netreg);
-        $kkt = $return_values[0]; $netreg = $return_values[1];
+        $kkt = $return_values[0];
+        $netreg = $return_values[1];
         $new_internet_expire_date = $return_values[2];
 
         $internet_expiration_message = null;
@@ -96,8 +97,12 @@ class EconomicController extends Controller
             ]);
         }
 
-        Mail::to($payer)->queue(new \App\Mail\Transactions($payer->name, [$kkt, $netreg],
-                 "Tranzakció létrehozva", $internet_expiration_message));
+        Mail::to($payer)->queue(new \App\Mail\Transactions(
+            $payer->name,
+            [$kkt, $netreg],
+            "Tranzakció létrehozva",
+            $internet_expiration_message
+        ));
 
         return redirect()->back()->with('message', __('general.successfully_added'));
     }

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -85,10 +85,8 @@ class EconomicController extends Controller
         $validator->validate();
 
         $payer = User::findOrFail($request->user_id);
-        $return_values = $payer->payKKTNetreg($request->kkt, $request->netreg);
-        $kkt = $return_values[0];
-        $netreg = $return_values[1];
-        $new_internet_expire_date = $return_values[2];
+        // the current user will be the receiver
+        [$kkt, $netreg, $new_internet_expire_date] = $payer->payKKTNetreg(Auth::user()->id, $request->kkt, $request->netreg);
 
         $internet_expiration_message = null;
         if ($new_internet_expire_date !== null) {
@@ -112,7 +110,7 @@ class EconomicController extends Controller
      */
     public function calculateWorkshopBalance()
     {
-        WorkshopBalance::generateBalances(Semester::current()->id);
+        WorkshopBalance::generateBalances(Semester::current());
 
         return redirect()->back()->with('message', __('general.successful_modification'));
     }

--- a/app/Http/Controllers/StudentsCouncil/EconomicController.php
+++ b/app/Http/Controllers/StudentsCouncil/EconomicController.php
@@ -50,7 +50,7 @@ class EconomicController extends Controller
         return view(
             'student-council.economic-committee.app',
             array_merge($this->getData($this->checkout()), [
-                'users_not_payed' => User::hasToPayKKTNetreg()->get()
+                'users_not_paid' => User::hasToPayKKTNetreg()->get()
             ])
         );
     }
@@ -63,7 +63,7 @@ class EconomicController extends Controller
         $this->authorize('addKKTNetreg', Checkout::class);
 
         return view('student-council.economic-committee.kktnetreg', [
-            'users_not_payed' => User::hasToPayKKTNetreg()->get(),
+            'users_not_paid' => User::hasToPayKKTNetreg()->get(),
             'transactions' => Transaction::whereIn('payment_type_id', [PaymentType::kkt()->id, PaymentType::netreg()->id])
                     ->where('semester_id', Semester::current()->id)
                     ->get()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -681,10 +681,13 @@ class User extends Authenticatable implements HasLocalePreference
      */
     public function isResident(): bool
     {
-        return $this->roles()
-        ->where('role_id', Role::collegist()->id)
-        ->where('object_id', RoleObject::firstWhere('name', Role::RESIDENT)->id)
-        ->exists();
+        if($this->verified == false) {
+            return $this->roles()
+            ->where('role_id', Role::collegist()->id)
+            ->where('object_id', RoleObject::firstWhere('name', Role::RESIDENT)->id)
+            ->exists();
+        }
+        return $this->hasRole([Role::COLLEGIST => Role::RESIDENT]);
     }
 
     /**
@@ -703,10 +706,13 @@ class User extends Authenticatable implements HasLocalePreference
      */
     public function isExtern(): bool
     {
-        return $this->roles()
-        ->where('role_id', Role::collegist()->id)
-        ->where('object_id', RoleObject::firstWhere('name', Role::EXTERN)->id)
-        ->exists();
+        if($this->verified == false) {
+            return $this->roles()
+            ->where('role_id', Role::collegist()->id)
+            ->where('object_id', RoleObject::firstWhere('name', Role::EXTERN)->id)
+            ->exists();
+        }
+        return $this->hasRole([Role::COLLEGIST => Role::EXTERN]);
     }
 
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -869,45 +869,6 @@ class User extends Authenticatable implements HasLocalePreference
     /* Transaction related */
 
     /**
-     * Pay kkt and netreg to the receiver given.
-     * Also updates workshop balances
-     * and the internet access expiry date.
-     * Returns an array with the two transaction objects
-     * and the new expiry date.
-     */
-    public function payKKTNetreg(int $receiver_id, int $kkt_amount, int $netreg_amount)
-    {
-        // Creating transactions
-        $kkt = Transaction::create([
-            'checkout_id' => Checkout::studentsCouncil()->id,
-            'receiver_id' => $receiver_id,
-            'payer_id' => $this->id,
-            'semester_id' => Semester::current()->id,
-            'amount' => $kkt_amount,
-            'payment_type_id' => PaymentType::kkt()->id,
-            'comment' => null,
-            'moved_to_checkout' => null,
-        ]);
-
-        $netreg = Transaction::create([
-            'checkout_id' => Checkout::admin()->id,
-            'receiver_id' => $receiver_id,
-            'payer_id' => $this->id,
-            'semester_id' => Semester::current()->id,
-            'amount' => $netreg_amount,
-            'payment_type_id' => PaymentType::netreg()->id,
-            'comment' => null,
-            'moved_to_checkout' => null,
-        ]);
-
-        WorkshopBalance::generateBalances(Semester::current());
-
-        $new_expiry_date = \App\Http\Controllers\Network\InternetController::extendUsersInternetAccess($this);
-
-        return [$kkt, $netreg, $new_expiry_date];
-    }
-
-    /**
      * Returns the paid kkt amount in the semester; or null if the user has not paid kkt.
      * @param Semester $semester
      * @return ?int

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -908,11 +908,11 @@ class User extends Authenticatable implements HasLocalePreference
     }
 
     /**
-     * Returns the payed kkt amount in the semester; or null if the user has not payed kkt.
+     * Returns the paid kkt amount in the semester; or null if the user has not paid kkt.
      * @param Semester $semester
      * @return ?int
      */
-    public function payedKKTInSemester(Semester $semester): ?int
+    public function paidKKTInSemester(Semester $semester): ?int
     {
         $transaction = $this->transactionsPaid()
             ->where('payment_type_id', PaymentType::kkt()->id)
@@ -923,12 +923,12 @@ class User extends Authenticatable implements HasLocalePreference
     }
 
     /**
-     * Returns the payed kkt amount in the current semester; or null if the user has not payed kkt.
+     * Returns the paid kkt amount in the current semester; or null if the user has not paid kkt.
      * @return ?int
      */
-    public function payedKKT(): ?int
+    public function paidKKT(): ?int
     {
-        return $this->payedKKTInSemester(Semester::current());
+        return $this->paidKKTInSemester(Semester::current());
     }
 
     /*

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -869,7 +869,8 @@ class User extends Authenticatable implements HasLocalePreference
      * Returns an array with the two transaction objects
      * and the new expiry date.
      */
-    public function payKKTNetreg(int $kkt_amount, int $netreg_amount) {
+    public function payKKTNetreg(int $kkt_amount, int $netreg_amount)
+    {
         // Creating transactions
         $kkt = Transaction::create([
             'checkout_id' => Checkout::studentsCouncil()->id,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -869,25 +869,25 @@ class User extends Authenticatable implements HasLocalePreference
     /* Transaction related */
 
     /**
-     * Returns the payed kkt amount in the semester. 0 if has not payed kkt.
+     * Returns the payed kkt amount in the semester; or null if the user has not payed kkt.
      * @param Semester $semester
-     * @return int
+     * @return ?int
      */
-    public function payedKKTInSemester(Semester $semester): int
+    public function payedKKTInSemester(Semester $semester): ?int
     {
         $transaction = $this->transactionsPaid()
             ->where('payment_type_id', PaymentType::kkt()->id)
             ->where('semester_id', $semester->id)
             ->first();
 
-        return $transaction ? $transaction->amount : 0;
+        return $transaction ? $transaction->amount : null;
     }
 
     /**
-     * Returns the payed kkt amount in the current semester. 0 if has not payed kkt.
-     * @return int
+     * Returns the payed kkt amount in the current semester; or null if the user has not payed kkt.
+     * @return ?int
      */
-    public function payedKKT(): int
+    public function payedKKT(): ?int
     {
         return $this->payedKKTInSemester(Semester::current());
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -671,7 +671,7 @@ class User extends Authenticatable implements HasLocalePreference
         $this->addRole($role, $object);
 
         Cache::forget('collegists');
-        WorkshopBalance::generateBalances(Semester::current()->id);
+        WorkshopBalance::generateBalances(Semester::current());
     }
 
     /**
@@ -863,18 +863,18 @@ class User extends Authenticatable implements HasLocalePreference
     /* Transaction related */
 
     /**
-     * Pay kkt and netreg.
+     * Pay kkt and netreg to the receiver given.
      * Also updates workshop balances
      * and the internet access expiry date.
      * Returns an array with the two transaction objects
      * and the new expiry date.
      */
-    public function payKKTNetreg(int $kkt_amount, int $netreg_amount)
+    public function payKKTNetreg(int $receiver_id, int $kkt_amount, int $netreg_amount)
     {
         // Creating transactions
         $kkt = Transaction::create([
             'checkout_id' => Checkout::studentsCouncil()->id,
-            'receiver_id' => Checkout::studentsCouncil()->handler_id,
+            'receiver_id' => $receiver_id,
             'payer_id' => $this->id,
             'semester_id' => Semester::current()->id,
             'amount' => $kkt_amount,
@@ -885,7 +885,7 @@ class User extends Authenticatable implements HasLocalePreference
 
         $netreg = Transaction::create([
             'checkout_id' => Checkout::admin()->id,
-            'receiver_id' => Checkout::studentsCouncil()->handler_id, // beware; the student council collects this, too!
+            'receiver_id' => $receiver_id,
             'payer_id' => $this->id,
             'semester_id' => Semester::current()->id,
             'amount' => $netreg_amount,
@@ -894,7 +894,7 @@ class User extends Authenticatable implements HasLocalePreference
             'moved_to_checkout' => null,
         ]);
 
-        WorkshopBalance::generateBalances(Semester::current()->id);
+        WorkshopBalance::generateBalances(Semester::current());
 
         $new_expiry_date = \App\Http\Controllers\Network\InternetController::extendUsersInternetAccess($this);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -869,6 +869,40 @@ class User extends Authenticatable implements HasLocalePreference
     /* Transaction related */
 
     /**
+     * Pay kkt and netreg.
+     * Also updates workshop balances
+     * and the internet access expiry date.
+     */
+    public function payKKTNetreg(int $kkt, int $netreg) {
+        // Creating transactions
+        $kkt = Transaction::create([
+            'checkout_id' => Checkout::studentsCouncil()->id,
+            'receiver_id' => Checkout::studentsCouncil()->handler_id,
+            'payer_id' => $this->id,
+            'semester_id' => Semester::current()->id,
+            'amount' => $kkt,
+            'payment_type_id' => PaymentType::kkt()->id,
+            'comment' => null,
+            'moved_to_checkout' => null,
+        ]);
+
+        $netreg = Transaction::create([
+            'checkout_id' => Checkout::admin()->id,
+            'receiver_id' => Checkout::studentsCouncil()->handler_id, // beware; the student council collects this, too!
+            'payer_id' => $this->id,
+            'semester_id' => Semester::current()->id,
+            'amount' => $netreg,
+            'payment_type_id' => PaymentType::netreg()->id,
+            'comment' => null,
+            'moved_to_checkout' => null,
+        ]);
+
+        WorkshopBalance::generateBalances(Semester::current()->id);
+
+        $new_internet_expire_date = \App\Http\Controllers\Network\InternetController::extendUsersInternetAccess($this);
+    }
+
+    /**
      * Returns the payed kkt amount in the semester; or null if the user has not payed kkt.
      * @param Semester $semester
      * @return ?int

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -878,7 +878,7 @@ class User extends Authenticatable implements HasLocalePreference
         $transaction = $this->transactionsPaid()
             ->where('payment_type_id', PaymentType::kkt()->id)
             ->where('semester_id', $semester->id)
-            ->get();
+            ->first();
 
         return $transaction ? $transaction->amount : 0;
     }

--- a/app/Models/Workshop.php
+++ b/app/Models/Workshop.php
@@ -82,9 +82,9 @@ class Workshop extends Model
      * Returns the balance for a given semester
      * (by default the current one).
      */
-    public function balance(int $semester = null): WorkshopBalance
+    public function balance(int $semester = null): ?WorkshopBalance
     {
-        return $this->balances()->where('semester_id', $semester ?? Semester::current()->id)->firstOrFail();
+        return $this->balances()->firstWhere('semester_id', $semester ?? Semester::current()->id);
     }
 
     public function color()

--- a/app/Models/Workshop.php
+++ b/app/Models/Workshop.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property integer $id
@@ -67,6 +68,23 @@ class Workshop extends Model
         return $this->users->filter(function ($user, $key) {
             return $user->isExtern();
         });
+    }
+
+    /**
+     * Returns all the balances the workshop has had in different semesters.
+     */
+    public function balances(): HasMany
+    {
+        return $this->hasMany(WorkshopBalance::class);
+    }
+
+    /**
+     * Returns the balance for a given semester
+     * (by default the current one).
+     */
+    public function balance(int $semester = null): WorkshopBalance
+    {
+        return $this->balances()->where('semester_id', $semester ?? Semester::current()->id)->firstOrFail();
     }
 
     public function color()

--- a/app/Models/WorkshopBalance.php
+++ b/app/Models/WorkshopBalance.php
@@ -65,7 +65,7 @@ class WorkshopBalance extends Model
             $not_yet_paid = 0;
             foreach ($workshop->users as $member) {
                 if (isset($active_users[$member->id])) {
-                    if ($member->payedKKTInSemester(Semester::find($semester_id)) != 0) {
+                    if (!is_null($member->payedKKTInSemester(Semester::find($semester_id)))) {
                         $user = $active_users[$member->id];
                         $amount = config('custom.kkt');
                         if ($user->isResident()) {

--- a/app/Models/WorkshopBalance.php
+++ b/app/Models/WorkshopBalance.php
@@ -38,16 +38,17 @@ class WorkshopBalance extends Model
      *                              : $workshop_balance_extern)
      *                / member's workshops' count
      * Uses the config values for the ratios if they are null.
-     * 
+     *
      * @param Semester $semester
      * @param ?float $workshop_balance_resident
      * @param ?float $workshop_balance_extern
      * @return void
      */
-    public static function generateBalances(Semester $semester,
-                                            ?float $workshop_balance_resident = null,
-                                            ?float $workshop_balance_extern = null): void
-    {
+    public static function generateBalances(
+        Semester $semester,
+        ?float $workshop_balance_resident = null,
+        ?float $workshop_balance_extern = null
+    ): void {
         if (is_null($workshop_balance_resident)) {
             $workshop_balance_resident = config("custom.workshop_balance_resident");
         }

--- a/app/Models/WorkshopBalance.php
+++ b/app/Models/WorkshopBalance.php
@@ -59,9 +59,9 @@ class WorkshopBalance extends Model
             $not_yet_paid = 0;
             foreach ($workshop->users as $member) {
                 if (isset($active_users[$member->id])) {
-                    $amount = $member->payedKKTInSemester(Semester::find($semester_id));
-                    if ($amount != 0) {
+                    if ($member->payedKKTInSemester(Semester::find($semester_id)) != 0) {
                         $user = $active_users[$member->id];
+                        $amount = config('custom.kkt');
                         if ($user->isResident()) {
                             $amount *= config('custom.workshop_balance_resident');
                             $resident++;

--- a/app/Models/WorkshopBalance.php
+++ b/app/Models/WorkshopBalance.php
@@ -65,17 +65,16 @@ class WorkshopBalance extends Model
             $not_yet_paid = 0;
             foreach ($workshop->users as $member) {
                 if (isset($active_users[$member->id])) {
-                    if (!is_null($member->payedKKTInSemester($semester))) {
-                        $user = $active_users[$member->id];
-                        $amount = config('custom.kkt');
-                        if ($user->isResident()) {
+                    $amount = $member->payedKKTInSemester($semester);
+                    if (!is_null($amount)) {
+                        if ($member->isResident()) {
                             $amount *= config('custom.workshop_balance_resident');
                             $resident++;
                         } else {
                             $amount *= config('custom.workshop_balance_extern');
                             $extern++;
                         }
-                        $balance += $amount / $user->workshops->count();
+                        $balance += $amount / $member->workshops->count();
                     } else {
                         $not_yet_paid++;
                     }

--- a/app/Models/WorkshopBalance.php
+++ b/app/Models/WorkshopBalance.php
@@ -15,11 +15,17 @@ class WorkshopBalance extends Model
         'used_balance',
     ];
 
+    /**
+     * Returns the workshop the balance belongs to.
+     */
     public function workshop()
     {
         return $this->belongsTo('App\Models\Workshop');
     }
 
+    /**
+     * Returns the semester the balance has been calculated for.
+     */
     public function semester()
     {
         return $this->belongsTo('App\Models\Semester');

--- a/app/Utils/CheckoutHandler.php
+++ b/app/Utils/CheckoutHandler.php
@@ -179,7 +179,7 @@ trait CheckoutHandler
      * Create a basic expense transaction in the checkout.
      * The receiver and the payer also will be the authenticated user
      * (since this does not mean a payment between users, just a transaction from the checkout).
-     * The only exception for the payer is when the checkout handler administrates a transaction payed by someone else.
+     * The only exception for the payer is when the checkout handler administrates a transaction paid by someone else.
      * We require a receipt here.
      *
      * @param Request $request

--- a/resources/views/student-council/economic-committee/app.blade.php
+++ b/resources/views/student-council/economic-committee/app.blade.php
@@ -31,7 +31,7 @@
                                     @can('administrate', $checkout)
                                     <blockquote>A gazdasági alelnök, a kulturális bizottság tagjai és a rendszergazdák szedhetnek be KKT-t/Netreget. Ezeket a tranzakciókat a tartozások alatt találod.</blockquote>
                                     @endcan
-                                    <x-input.select l=4 :elements="$users_not_payed" id="user_id" text="general.user" :formatter="function($user) { return $user->uniqueName; }" />
+                                    <x-input.select l=4 :elements="$users_not_paid" id="user_id" text="general.user" :formatter="function($user) { return $user->uniqueName; }" />
                                     <x-input.text  m=6 l=4 id="kkt" text="KKT" type="number" required min="0" :value="config('custom.kkt')" />
                                     <x-input.text  m=6 l=4 id="netreg" text="NetReg" type="number" required min="0" :value="config('custom.netreg')" />
                                 </div>

--- a/resources/views/student-council/economic-committee/kktnetreg.blade.php
+++ b/resources/views/student-council/economic-committee/kktnetreg.blade.php
@@ -15,7 +15,7 @@
             <div class="card-content">
                 <span class="card-title">Még nem fizettek ({{ \App\Models\Semester::current()->tag }}) </span>
                 <table><tbody>
-                    @foreach($users_not_payed as $user)
+                    @foreach($users_not_paid as $user)
                       <tr><td>{{ $user->uniqueName }}</td></tr>
                     @endforeach
                 </tbody></table>

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -4,13 +4,13 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 
-use \App\Models\User;
-use \App\Models\Transaction;
-use \App\Models\PaymentType;
-use \App\Models\Semester;
-use \App\Models\SemesterStatus;
-use \App\Models\Workshop;
-use \App\Models\WorkshopBalance;
+use App\Models\User;
+use App\Models\Transaction;
+use App\Models\PaymentType;
+use App\Models\Semester;
+use App\Models\SemesterStatus;
+use App\Models\Workshop;
+use App\Models\WorkshopBalance;
 
 class EconomicTest extends TestCase
 {
@@ -61,14 +61,16 @@ class EconomicTest extends TestCase
      */
     public function testPayment()
     {
-        foreach ([true, false] as $is_extern)
-        {
+        foreach ([true, false] as $is_extern) {
             $workshop_id = rand(1, count(Workshop::ALL));
             $workshop = Workshop::findOrFail($workshop_id);
             $user = User::factory()->create();
 
-            if ($is_extern) $user->setExtern();
-            else $user->setCollegist(\App\Models\Role::RESIDENT);
+            if ($is_extern) {
+                $user->setExtern();
+            } else {
+                $user->setCollegist(\App\Models\Role::RESIDENT);
+            }
 
             $user->setStatusFor(Semester::current(), SemesterStatus::ACTIVE);  // important!
 
@@ -93,9 +95,10 @@ class EconomicTest extends TestCase
             $this->assertTrue($user->payedKKT() == config('custom.kkt'));
 
             $this->assertTrue($new - $old == round(
-                                               ($is_extern ? config('custom.workshop_balance_extern')
+                ($is_extern ? config('custom.workshop_balance_extern')
                                                            : config('custom.workshop_balance_resident'))
-                                               * config('custom.kkt')));
+                                               * config('custom.kkt')
+            ));
         }
     }
 }

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 
+use App\Http\Controllers\StudentsCouncil\EconomicController;
 use App\Models\Checkout;
 use App\Models\Role;
 use App\Models\User;
@@ -51,9 +52,9 @@ class EconomicTest extends TestCase
         // the old allocated balances
         $old_balances = $workshops->map(fn ($workshop) => $workshop->balance()->allocated_balance);
 
-        // we give the payer's id as the receiver's id
+        // we give the payer as the receiver too
         // because Checkout::studentsCouncil()->handler_id returns null
-        $user->payKKTNetreg($user->id, self::TEST_KKT, self::TEST_NETREG);
+        EconomicController::payKKTNetregLogic($user, $user, self::TEST_KKT, self::TEST_NETREG);
         // since this uses the config values to generate balances,
         // we have to redo it:
         WorkshopBalance::generateBalances(Semester::current(),

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -47,7 +47,9 @@ class EconomicTest extends TestCase
         }
 
         $user->setStatusFor(Semester::current(), SemesterStatus::ACTIVE);  // important!
-        foreach($workshops as $workshop) $user->workshops()->attach($workshop);
+        foreach($workshops as $workshop) {
+            $user->workshops()->attach($workshop);
+        }
 
         $this->assertTrue(is_null($user->payedKKT()));
         WorkshopBalance::generateBalances(Semester::current()); // this also ensures the balance won't be null
@@ -74,7 +76,7 @@ class EconomicTest extends TestCase
             $this->assertTrue(abs(
                 $number_of_workshops * ($news[$i] - $olds[$i])
                                 - $amount_for_workshops
-                ) < self::THRESHOLD_DIFF);
+            ) < self::THRESHOLD_DIFF);
         }
     }
 

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -32,7 +32,7 @@ class EconomicTest extends TestCase
      * Does it for a user with an active status,
      * who can be a resident or an extern
      * and can have one or multiple workshops.
-     * 
+     *
      * In the test cases,
      * we provide users with
      * these parameters varied.
@@ -45,9 +45,11 @@ class EconomicTest extends TestCase
         $workshops = $user->workshops;
 
         // this also ensures the balance won't be null
-        WorkshopBalance::generateBalances(Semester::current(),
-                                          self::TEST_RATIO_RESIDENT,
-                                          self::TEST_RATIO_EXTERN);
+        WorkshopBalance::generateBalances(
+            Semester::current(),
+            self::TEST_RATIO_RESIDENT,
+            self::TEST_RATIO_EXTERN
+        );
 
         // the old allocated balances
         $old_balances = $workshops->map(fn ($workshop) => $workshop->balance()->allocated_balance);
@@ -57,9 +59,11 @@ class EconomicTest extends TestCase
         EconomicController::payKKTNetregLogic($user, $user, self::TEST_KKT, self::TEST_NETREG);
         // since this uses the config values to generate balances,
         // we have to redo it:
-        WorkshopBalance::generateBalances(Semester::current(),
-                                          self::TEST_RATIO_RESIDENT,
-                                          self::TEST_RATIO_EXTERN);
+        WorkshopBalance::generateBalances(
+            Semester::current(),
+            self::TEST_RATIO_RESIDENT,
+            self::TEST_RATIO_EXTERN
+        );
 
         $this->assertEquals($user->paidKKT(), self::TEST_KKT);
 

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -21,7 +21,7 @@ class EconomicTest extends TestCase
 
         $transactions = \App\Models\Transaction::whereIn(
             'payment_type_id',
-            [\App\Models\PaymentType::kkt()->id, \App\Models\PaymentType::netreg()->id]
+            [\App\Models\PaymentType::kkt()->id]
         )
             ->where('semester_id', \App\Models\Semester::current()->id)
             ->get();

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class EconomicTest extends TestCase
+{
+    /**
+     * This test is to ensure that the sum of workshop balances
+     * is between
+     * config('custom.workshop_balance_resident)*skkt and
+     * config('custom.workshop_balance_extern)*skkt
+     * (where skkt is the entire income got from kkt).
+     *
+     * @return void
+     */
+    public function testWorkshopRatio()
+    {
+        // Should we generate users here?
+
+        $transactions = \App\Models\Transaction::whereIn('payment_type_id',
+          [\App\Models\PaymentType::kkt()->id, \App\Models\PaymentType::netreg()->id])
+            ->where('semester_id', \App\Models\Semester::current()->id)
+            ->get();
+        $skkt = $transactions->where('payment_type_id', \App\Models\PaymentType::kkt()->id)
+            ->sum('amount');
+
+        \App\Models\WorkshopBalance::generateBalances(\App\Models\Semester::current()->id);
+        $sum = \App\Models\WorkshopBalance::all()->sum('allocated_balance');
+
+        /*
+        echo($skkt);
+        echo("\n");
+        echo($sum);
+        echo("\n");
+        echo(config('custom.workshop_balance_resident'));
+        echo("\n");
+        echo(config('custom.workshop_balance_extern'));
+        echo("\n");
+        */
+
+        $diff1 = config('custom.workshop_balance_resident') * $skkt - $sum;
+        $diff2 = config('custom.workshop_balance_extern') * $skkt - $sum;
+        $this->assertTrue($diff1 * $diff2 <= 0);
+    }
+}

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -25,45 +25,6 @@ class EconomicTest extends TestCase
     public const THRESHOLD_DIFF = 1.5;
 
     /**
-     * This test is to ensure that the sum of workshop balances
-     * is between
-     * config('custom.workshop_balance_resident)*skkt and
-     * config('custom.workshop_balance_extern)*skkt
-     * (where skkt is the entire income got from kkt).
-     * @return void
-     */
-    public function testWorkshopRatio()
-    {
-        // Should we generate users here?
-
-        $skkt = \App\Models\Transaction::where(
-            'payment_type_id',
-            \App\Models\PaymentType::kkt()->id
-        )
-            ->where('semester_id', \App\Models\Semester::current()->id)
-            ->sum('amount');
-
-        \App\Models\WorkshopBalance::generateBalances(\App\Models\Semester::current());
-        $sum = \App\Models\WorkshopBalance::where('semester_id', \App\Models\Semester::current()->id)
-            ->sum('allocated_balance');
-
-        /*
-        echo($skkt);
-        echo("\n");
-        echo($sum);
-        echo("\n");
-        echo(config('custom.workshop_balance_resident'));
-        echo("\n");
-        echo(config('custom.workshop_balance_extern'));
-        echo("\n");
-        */
-
-        $diff1 = config('custom.workshop_balance_resident') * $skkt - $sum;
-        $diff2 = config('custom.workshop_balance_extern') * $skkt - $sum;
-        $this->assertTrue($diff1 * $diff2 <= 0);
-    }
-
-    /**
      * Tests how workshop balances change
      * when a user pays kkt.
      * Does it for externs or residents;

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -19,8 +19,10 @@ class EconomicTest extends TestCase
     {
         // Should we generate users here?
 
-        $transactions = \App\Models\Transaction::whereIn('payment_type_id',
-          [\App\Models\PaymentType::kkt()->id, \App\Models\PaymentType::netreg()->id])
+        $transactions = \App\Models\Transaction::whereIn(
+            'payment_type_id',
+            [\App\Models\PaymentType::kkt()->id, \App\Models\PaymentType::netreg()->id]
+        )
             ->where('semester_id', \App\Models\Semester::current()->id)
             ->get();
         $skkt = $transactions->where('payment_type_id', \App\Models\PaymentType::kkt()->id)

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -13,8 +13,15 @@ use App\Models\SemesterStatus;
 use App\Models\Workshop;
 use App\Models\WorkshopBalance;
 
+/**
+ * Tests for the function tracking kkt payments and workshop balances.
+ */
 class EconomicTest extends TestCase
 {
+    // We use constants for now as kkt and netreg values.
+    public const TEST_KKT = 2500;
+    public const TEST_NETREG = 500;
+
     /**
      * This test is to ensure that the sum of workshop balances
      * is between
@@ -86,16 +93,16 @@ class EconomicTest extends TestCase
             $old = $balance->allocated_balance;
             // we give the payer's id as the receiver's id
             // because Checkout::studentsCouncil()->handler_id returns null
-            $user->payKKTNetreg($user->id, config('custom.kkt'), config('custom.netreg'));
+            $user->payKKTNetreg($user->id, self::TEST_KKT, self::TEST_NETREG);
             $balance->refresh();
             $new = $balance->allocated_balance;
 
-            $this->assertTrue($user->payedKKT() == config('custom.kkt'));
+            $this->assertTrue($user->payedKKT() == self::TEST_KKT);
 
             $this->assertTrue($new - $old == round(
                 ($is_extern ? config('custom.workshop_balance_extern')
-                                                           : config('custom.workshop_balance_resident'))
-                                               * config('custom.kkt')
+                            : config('custom.workshop_balance_resident'))
+                    * self::TEST_KKT
             ));
         }
     }

--- a/tests/Unit/EconomicTest.php
+++ b/tests/Unit/EconomicTest.php
@@ -19,17 +19,16 @@ class EconomicTest extends TestCase
     {
         // Should we generate users here?
 
-        $transactions = \App\Models\Transaction::whereIn(
+        $skkt = \App\Models\Transaction::where(
             'payment_type_id',
-            [\App\Models\PaymentType::kkt()->id]
+            \App\Models\PaymentType::kkt()->id
         )
             ->where('semester_id', \App\Models\Semester::current()->id)
-            ->get();
-        $skkt = $transactions->where('payment_type_id', \App\Models\PaymentType::kkt()->id)
             ->sum('amount');
 
         \App\Models\WorkshopBalance::generateBalances(\App\Models\Semester::current()->id);
-        $sum = \App\Models\WorkshopBalance::all()->sum('allocated_balance');
+        $sum = \App\Models\WorkshopBalance::where('semester_id', \App\Models\Semester::current()->id)
+            ->sum('allocated_balance');
 
         /*
         echo($skkt);


### PR DESCRIPTION
There was a strange phenomenon with the workshop balances: their sum was more than 49% of the amount received from kkt payments; in theory, it should be between 30% and 40%.

I've rewritten the algorithm calculating the data in the balances table; now it displays less people paying kkt and it seems to be consistent with the income numbers. @kdmnk could you check it out?