### PR TITLE
Fix internet admin page memory issue

### DIFF
--- a/app/Http/Controllers/Network/InternetController.php
+++ b/app/Http/Controllers/Network/InternetController.php
@@ -41,7 +41,7 @@ class InternetController extends Controller
         $this->authorize('handleAny', InternetAccess::class);
 
         $activationDate = self::getInternetDeadline();
-        $users = User::withRole(Role::INTERNET_USER)->with('internetAccess.wifiConnections')->get();
+        $users = User::withRole(Role::INTERNET_USER)->with('internetAccess')->get();
 
         return view('network.manage.app', ['activation_date' => $activationDate, 'users' => $users]);
     }


### PR DESCRIPTION
The internet connections were preloaded with the users data which is not used because the internet access table already uses a different endpoint (with pagination).