### PR TITLE
Fixing payment buttons on checkout pages

### DIFF
--- a/resources/sass/materialize.scss
+++ b/resources/sass/materialize.scss
@@ -31,6 +31,8 @@ i.material-icons {
     font-family: 'Material Icons', 'Open Sans', 'sans-serif';
     font-style: normal;
     font-size: x-large;
+    //this fixed the payment buttons on checkout pages
+    text-transform: none;
 }
 
 /* overwrite some materialize classes */


### PR DESCRIPTION
The text was displayed instead of the material icon. Overriding the text-transform property in the SCSS fixed the issue.