### PR TITLE
fix typo in "transaction email"

### DIFF
--- a/resources/views/emails/transactions.blade.php
+++ b/resources/views/emails/transactions.blade.php
@@ -14,9 +14,9 @@
 {{ $transaction->comment }}: {{ abs($transaction->amount) }} Ft.
 @if($transaction->payer!=$transaction->receiver)
     Átvevő: {{ $transaction->receiver?->name ?? "N/A" }},
-    Fizető: {{ $transaction->payer?->name ?? "N/A" }})
+    Fizető: {{ $transaction->payer?->name ?? "N/A" }}
 @elseif($recipent != $transaction->payer?->name)
-    Fizető: {{ $transaction->payer?->name ?? "N/A" }})
+    Fizető: {{ $transaction->payer?->name ?? "N/A" }}
 @endif
 </li>
 @endforeach


### PR DESCRIPTION
I removed parentheses that shouldn't have been there.