### PR TITLE
Obey browser language preferences

### DIFF
--- a/app/Http/Middleware/Locale.php
+++ b/app/Http/Middleware/Locale.php
@@ -16,7 +16,8 @@ class Locale
      */
     public function handle($request, Closure $next)
     {
-        App::setLocale($request->cookie('locale', config('app.locale')));
+        $locales = array_keys(config('app.locales'));
+        App::setLocale($request->cookie('locale', $request->getPreferredLanguage($locales)));
         return $next($request);
     }
 }


### PR DESCRIPTION
Before this change, the site would always be displayed in Hungarian until the user explicitly set their language preferences in the menu. This is inconvenient for guests who do not speak the language; I personally had to had to help a guest sign up, as they did not notice the hamburger menu on their phone.

This change makes the `Locale` middleware select the appropriate language via the `Accept-Language` header. It can still be overridden via the Language menu.