### PR TITLE
Changing MySQL host to 127.0.0.1 while creating Gitpod workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,7 @@ tasks:
       cp .env.example .env &&
       sed -i "s#APP_URL=http://localhost#APP_URL=$(gp url 8000)#g" .env
       sed -i "s#GITPOD_VITE_URL=#GITPOD_VITE_URL=$(gp url 5173)#g" .env
+      sed -i "s#DB_HOST=.*\$#DB_HOST=127.0.0.1#g" .env
       composer install --ignore-platform-reqs
       php artisan key:generate
       php artisan storage:link


### PR DESCRIPTION
In `gitpod.yml`, the `.env` file was not updated with the database host. It seems `127.0.0.1` works well.

Can you check this out as soon as possible? (Btw, I'm planning to create a short tutorial video on our Gitpod workspaces.)