### PR TITLE
Docker dev setup: fix project name, add PHPStorm tips

### DIFF
--- a/docker-dev-setup/Dockerfile
+++ b/docker-dev-setup/Dockerfile
@@ -17,6 +17,6 @@ RUN wget -nv -O node.tar.xz https://nodejs.org/dist/v20.9.0/node-v20.9.0-linux-x
     rm node.tar.xz
 ENV PATH=$PATH:/workspace/node-v20.9.0-linux-x64/bin
 
-WORKDIR /workspace/mnt
+WORKDIR /workspace/mars
 
 CMD ["/usr/bin/sleep", "infinity"]

--- a/docker-dev-setup/README.md
+++ b/docker-dev-setup/README.md
@@ -85,6 +85,10 @@ You can use an IDE or text editor of your choice. Here are some recommended IDEs
 
 - Set up a [remote PHP interpreter](https://www.jetbrains.com/help/phpstorm/configuring-remote-interpreters.html) using Docker Compose
   - Select the `docker-dev-setup/docker-compose.yml` configuration file and the `mars_dev` service
+- Add support for Laravel Eloquent:
+  - Generate IDE helper files: `docker exec mars_dev bash -c "php artisan clear-compiled && php artisan ide-helper:refresh"`
+  - In PHPStorm click on: `File / Invalidate caches / Invalidate and Restart`
+  - Now `self::where(...)`, `@mixin \Eloquent`, etc. shouldn't get marked as errors
 
 #### Visual Studio Code (vsc, vscode)
 

--- a/docker-dev-setup/docker-compose.yml
+++ b/docker-dev-setup/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     depends_on:
       - mars_mysql
     volumes:
-      - "..:/workspace/mnt"
+      - "..:/workspace/mars"
     ports:
       - '127.0.0.1:8000:8000'
 


### PR DESCRIPTION
By renaming `mnt` to `mars` the `package-lock.json` file doesn't get modified. This file is checked into version control, therefore this difference matters. Before the rename, the file's `name` property got changed from `mars` to `mnt`.

I have also added some more tips related to PHPStorm.