### PR TITLE
Fix issues with escapings with forms

### DIFF
--- a/app/View/Components/Input/Textarea.php
+++ b/app/View/Components/Input/Textarea.php
@@ -7,6 +7,7 @@ use App\View\Components\Input;
 class Textarea extends Input
 {
     public $helper;
+    public $withoutLabel;
 
     /**
      * Create a new textarea input instance.
@@ -14,10 +15,11 @@ class Textarea extends Input
      * @param  string  $helper  helper message
      * @return void
      */
-    public function __construct($id, $helper = null, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false)
+    public function __construct($id, $withoutLabel = false, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $helper = null)
     {
         parent::__construct($id, $text, $s, $m, $l, $xl, $onlyInput);
         $this->helper = $helper;
+        $this->withoutLabel = $withoutLabel;
     }
 
     /**

--- a/resources/views/auth/application/applications_details.blade.php
+++ b/resources/views/auth/application/applications_details.blade.php
@@ -16,7 +16,7 @@
                     <x-input.textarea id="note"
                                       text="Megjegyzés"
                                       helper="A megjegyzéseket a felvételiző nem látja, de azok láthatóak a többi felvételiztető számára (akár más műhelyekből is)."
-                                      :value="$user->application->note"/>
+                                      >{{ $user->application->note }}</x-input.textarea>
                 </div>
                 <x-input.button floating class="right" icon="save"/>
             </div>

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -97,23 +97,22 @@
                             @endif
                         @endforeach
                         <div class="input-field" style="margin: 0; padding-left:35px">
-                            <x-input.text only-input id="question_1_other"
-                                          :value="$user->application->question_1_custom" name="question_1[]"
-                                          without-label placeholder="egyéb/bővebben..."/>
+                            <x-input.textarea only-input id="question_1_other" name="question_1[]"
+                                          without-label placeholder="egyéb/bővebben...">{{$user->application->question_1_custom}}</x-input.textarea>
                         </div>
                     </div>
                     <x-input.textarea id="question_2" text="Miért kíván a Collegium tagja lenni?"
-                                      helper="≈300-500 karakter" :value="$user->application->question_2"/>
+                                      helper="≈300-500 karakter">{{$user->application->question_2}}</x-input.textarea>
                     <x-input.textarea id="question_3"
                                       text="Tervez-e tovább tanulni a diplomája megszerzése után? Milyen tervei vannak az egyetem után?"
-                                      :value="$user->application->question_3"/>
+                                      >{{$user->application->question_3}}</x-input.textarea>
                     <x-input.textarea id="question_4"
                                       text="Részt vett-e közéleti tevékenységben? Ha igen, röviden jellemezze!"
                                       helper="Pl. diákönkormányzati tevékenység, önkéntesség, szervezeti tagság. (nem kötelező)"
-                                      :value="$user->application->question_4"/>
+                                      >{{$user->application->question_4}}</x-input.textarea>
                     <x-input.textarea id="present"
                                       text="Amennyiben nem tud jelen lenni a felvételi teljes ideje alatt (vasárnap-szerda), kérjük itt indoklással jelezze!"
-                                      :value="$user->application->present"  helper="Változás esetén értesítse a titkárságot!"/>
+                                      helper="Változás esetén értesítse a titkárságot!">{{$user->application->present}}</x-input.textarea>
                     <x-input.checkbox id="accommodation"
                                       text="Igényel-e szállást a felvételi idejére?"
                                       :checked="$user->application->accommodation"/>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -10,7 +10,7 @@
                 <div class="card-content">
                     <div class="card-title"> @lang('passwords.resetpwd')</div>
                     <div class="row">
-                        <x-input.text id="email"      text="registration.email" type="email" :value="$email" required autocomplete="email" autofocus/>
+                        <x-input.textarea id="email"      text="registration.email" type="email" required autocomplete="email" autofocus>{{ $email }}</x-input.textarea>
                         <x-input.text id="password"   text="registration.password" type="password" required autocomplete="new-password"/>
                         <x-input.text id="confirmpwd" text="registration.confirmpwd" name="password_confirmation" type="password" required autocomplete="new-password"/>
                     </div>

--- a/resources/views/components/input/textarea.blade.php
+++ b/resources/views/components/input/textarea.blade.php
@@ -1,19 +1,24 @@
-@if(!$onlyInput)
+@if(!$onlyInput && !$attributes->get('hidden'))
 <div class="input-field col s{{$s}} m{{$m}} l{{$l}} xl{{$xl}}">
 @endif
     <textarea
         id="{{$id}}"
+        class="materialize-textarea validate @error($id) invalid @enderror"
+        {{-- Default values + other provided attributes --}}
         {{$attributes->whereDoesntStartWith('value')->merge([
-            'name' => $id,
-            'class' => "materialize-textarea validate"
-        ])}}>{{old($id) ?? $attributes->get('value')}}</textarea>
+            'type' => 'text',
+            'name' => $id
+        ])}}
+    >{{ $slot }}</textarea>
+    @if(!$attributes->get('hidden') && !$withoutLabel)
     <label for="{{$id}}">{{$label}}</label>
+    @endif
     @if($helper ?? null)
     <span class="helper-text">{{ $helper }}</span>
     @endif
     @error($id)
         <span class="helper-text" data-error="{{ $message }}"></span>
     @enderror
-@if(!$onlyInput)
+@if(!$onlyInput && !$attributes->get('hidden'))
 </div>
 @endif

--- a/resources/views/localizations/manage.blade.php
+++ b/resources/views/localizations/manage.blade.php
@@ -40,7 +40,7 @@
                                 @can('approve', $contribution);
                                 <form method="POST" action="{{ route('localizations.delete') }}">
                                     @csrf
-                                    <x-input.text type="number" id="id" :value="$contribution->id" hidden/>
+                                    <x-input.text type="number" id="id" :value="$contribution->id" hidden />
                                     <x-input.button floating class="red" icon="clear" />
                                 </form>
                                 @endcan

--- a/resources/views/network/routers/create.blade.php
+++ b/resources/views/network/routers/create.blade.php
@@ -17,22 +17,22 @@
                 <div class="card-content">
                     <span class="card-title">@lang('router.new')</span>
                     <div class="row">
-                        <x-input.textarea s="6" type="text" text="router.ip" id="ip" maxlength="15" required/>
-                        <x-input.textarea s="6" type="text" text="router.room" id="room" min="1" max="500" required/>
+                        <x-input.textarea s="6" text="router.ip" id="ip" maxlength="15" required/>
+                        <x-input.textarea s="6" text="router.room" id="room" maxlength="5" required/>
                     </div>
                     <div class="row">
-                        <x-input.textarea s="4" type="text" text="router.port" id="port"/>
-                        <x-input.textarea s="4" type="text" text="router.type" id="type"/>
-                        <x-input.textarea s="4" type="text" text="router.serial_number" id="serial_number"/>
+                        <x-input.textarea s="4" text="router.port" id="port"/>
+                        <x-input.textarea s="4" text="router.type" id="type"/>
+                        <x-input.textarea s="4" text="router.serial_number" id="serial_number"/>
                     </div>
                     <div><p>@lang('internet.mac_address')</p></div>
                     <div class="row">
-                        <x-input.textarea s="4" type="text" text="WAN" id="mac_WAN"/>
-                        <x-input.textarea s="4" type="text" text="2G/LAN" id="mac_2G_LAN"/>
-                        <x-input.textarea s="4" type="text" text="5G" id="mac_5G"/>
+                        <x-input.textarea s="4" text="WAN" id="mac_WAN"/>
+                        <x-input.textarea s="4" text="2G/LAN" id="mac_2G_LAN"/>
+                        <x-input.textarea s="4" text="5G" id="mac_5G"/>
                     </div>
                     <div class="row">
-                        <x-input.textarea type="text" id="comment" text="general.comment" maxlength="255"/>
+                        <x-input.textarea id="comment" text="general.comment" maxlength="255"/>
                     </div>
                     <div class="row">
                         <x-input.text s="6" type="date" id="date_of_acquisition" text="router.date_of_acquisition"/>

--- a/resources/views/network/routers/create.blade.php
+++ b/resources/views/network/routers/create.blade.php
@@ -17,22 +17,22 @@
                 <div class="card-content">
                     <span class="card-title">Új router</span>
                     <div class="row">
-                        <x-input.text s="6" type="text" text="router.ip" id="ip" maxlength="15" required/>
+                        <x-input.textarea s="6" type="text" text="router.ip" id="ip" maxlength="15" required/>
                         <x-input.text s="6" type="number" text="router.room" id="room" min="1" max="500" required/>
                     </div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="router.port" id="port"/>
-                        <x-input.text s="4" type="text" text="router.type" id="type"/>
-                        <x-input.text s="4" type="text" text="router.serial_number" id="serial_number"/>
+                        <x-input.textarea s="4" type="text" text="router.port" id="port"/>
+                        <x-input.textarea s="4" type="text" text="router.type" id="type"/>
+                        <x-input.textarea s="4" type="text" text="router.serial_number" id="serial_number"/>
                     </div>
                     <div><p>MAC cím</p></div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="WAN" id="mac_wan"/>
-                        <x-input.text s="4" type="text" text="2G/LAN" id="mac_2g_lan"/>
-                        <x-input.text s="4" type="text" text="5G" id="mac_5g"/>
+                        <x-input.textarea s="4" type="text" text="WAN" id="mac_wan"/>
+                        <x-input.textarea s="4" type="text" text="2G/LAN" id="mac_2g_lan"/>
+                        <x-input.textarea s="4" type="text" text="5G" id="mac_5g"/>
                     </div>
                     <div class="row">
-                        <x-input.text type="text" id="comment" text="general.comment" maxlength="255"/>
+                        <x-input.textarea type="text" id="comment" text="general.comment" maxlength="255"/>
                     </div>
                     <div class="row">
                         <x-input.text s="6" type="date" id="date_of_acquisition" text="router.date_of_acquisition"/>

--- a/resources/views/network/routers/edit.blade.php
+++ b/resources/views/network/routers/edit.blade.php
@@ -17,22 +17,22 @@
                 <div class="card-content">
                     <span class="card-title">@lang('router.edit')</span>
                     <div class="row">
-                        <x-input.textarea s="6" type="text" text="router.ip" id="ip" maxlength="15" required>{{ $router->ip }}</x-input.textarea>
-                        <x-input.textarea s="6" type="text" text="router.room" id="room" min="1" max="500" required>{{ $router->room }}</x-input.textarea>
+                        <x-input.textarea s="6" text="router.ip" id="ip" maxlength="15" required>{{ $router->ip }}</x-input.textarea>
+                        <x-input.textarea s="6" text="router.room" id="room" maxlength="5" required>{{ $router->room }}</x-input.textarea>
                     </div>
                     <div class="row">
-                        <x-input.textarea s="4" type="text" text="router.port" id="port">{{ $router->port }}</x-input.textarea>
-                        <x-input.textarea s="4" type="text" text="router.type" id="type">{{ $router->type }}</x-input.textarea>
-                        <x-input.textarea s="4" type="text" text="router.serial_number" id="serial_number">{{ $router->serial_number }}</x-input.textarea>
+                        <x-input.textarea s="4" text="router.port" id="port">{{ $router->port }}</x-input.textarea>
+                        <x-input.textarea s="4" text="router.type" id="type">{{ $router->type }}</x-input.textarea>
+                        <x-input.textarea s="4" text="router.serial_number" id="serial_number">{{ $router->serial_number }}</x-input.textarea>
                     </div>
                     <div><p>@lang('internet.mac_address')</p></div>
                     <div class="row">
-                        <x-input.textarea s="4" type="text" text="WAN" id="mac_WAN">{{ $router->mac_WAN }}</x-input.textarea>
-                        <x-input.textarea s="4" type="text" text="2G/LAN" id="mac_2G_LAN">{{ $router->mac_2G_LAN }}</x-input.textarea>
-                        <x-input.textarea s="4" type="text" text="5G" id="mac_5G">{{ $router->mac_5G }}</x-input.textarea>
+                        <x-input.textarea s="4" text="WAN" id="mac_WAN">{{ $router->mac_WAN }}</x-input.textarea>
+                        <x-input.textarea s="4" text="2G/LAN" id="mac_2G_LAN">{{ $router->mac_2G_LAN }}</x-input.textarea>
+                        <x-input.textarea s="4" text="5G" id="mac_5G">{{ $router->mac_5G }}</x-input.textarea>
                     </div>
                     <div class="row">
-                        <x-input.textarea type="text" id="comment" text="general.comment" maxlength="255">{{ $router->comment }}</x-input.textarea>
+                        <x-input.textarea id="comment" text="general.comment" maxlength="255">{{ $router->comment }}</x-input.textarea>
                     </div>
                     <div class="row">
                         <x-input.text s="6" type="date" id="date_of_acquisition" text="router.date_of_acquisition" value="{{ $router->date_of_acquisition }}"/>

--- a/resources/views/network/routers/edit.blade.php
+++ b/resources/views/network/routers/edit.blade.php
@@ -17,22 +17,23 @@
                 <div class="card-content">
                     <span class="card-title">Módosítás</span>
                     <div class="row">
-                        <x-input.text s="6" type="text" text="router.ip" id="ip" value="{{ $router->ip }}" maxlength="15" required/>
-                        <x-input.text s="6" type="number" text="router.room" id="room" value="{{ $router->room }}" min="1" max="500" required/>
+                        <x-input.textarea s="6" type="text" text="router.ip" id="ip" maxlength="15" required>{{ $router->ip }}</x-input.textarea>
+                        <x-input.text s="6" type="number" text="router.room" id="room" min="1" max="500" :value="$router->room" required>
+                        </x-input.text>
                     </div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="router.port" id="port" value="{{ $router->port }}"/>
-                        <x-input.text s="4" type="text" text="router.type" id="type" value="{{ $router->type }}"/>
-                        <x-input.text s="4" type="text" text="router.serial_number" id="serial_number" value="{{ $router->serial_number }}"/>
+                        <x-input.textarea s="4" type="text" text="router.port" id="port">{{ $router->port }}</x-input.textarea>
+                        <x-input.textarea s="4" type="text" text="router.type" id="type">{{ $router->type }}</x-input.textarea>
+                        <x-input.textarea s="4" type="text" text="router.serial_number" id="serial_number">{{ $router->serial_number }}</x-input.textarea>
                     </div>
                     <div><p>MAC cím</p></div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="WAN" id="mac_WAN" value="{{ $router->mac_WAN }}"/>
-                        <x-input.text s="4" type="text" text="2G/LAN" id="mac_2G_LAN" value="{{ $router->mac_2G_LAN }}"/>
-                        <x-input.text s="4" type="text" text="5G" id="mac_5G" value="{{ $router->mac_5G }}"/>
+                        <x-input.textarea s="4" type="text" text="WAN" id="mac_WAN">{{ $router->mac_WAN }}</x-input.textarea>
+                        <x-input.textarea s="4" type="text" text="2G/LAN" id="mac_2G_LAN">{{ $router->mac_2G_LAN }}</x-input.textarea>
+                        <x-input.textarea s="4" type="text" text="5G" id="mac_5G">{{ $router->mac_5G }}</x-input.textarea>
                     </div>
                     <div class="row">
-                        <x-input.text type="text" id="comment" text="general.comment" value="{{ $router->comment }}" maxlength="255"/>
+                        <x-input.textarea type="text" id="comment" text="general.comment" maxlength="255">{{ $router->comment }}</x-input.textarea>
                     </div>
                     <div class="row">
                         <x-input.datepicker s="6" id="date_of_acquisition" text="router.date_of_acquisition" value="{{ $router->date_of_acquisition }}"/>

--- a/resources/views/secretariat/evaluation-form/app.blade.php
+++ b/resources/views/secretariat/evaluation-form/app.blade.php
@@ -82,8 +82,8 @@
                             @csrf
                             <div class="row">
                                 <input type="hidden" name="section" value="alfonso"/>
-                                <x-input.text l=10 id="alfonso_note" :value="$evaluation?->alfonso_note"
-                                              text="Megjegyzés, helyesbítés, egyéni elbírálás"/>
+                                <x-input.textarea l=10 id="alfonso_note"
+                                              text="Megjegyzés, helyesbítés, egyéni elbírálás">{{ $evaluation?->alfonso_note }}</x-input.textarea>
                                 <x-input.button l=2 class="right" text="general.save"/>
                             </div>
                         </form>

--- a/resources/views/secretariat/evaluation-form/course.blade.php
+++ b/resources/views/secretariat/evaluation-form/course.blade.php
@@ -1,21 +1,19 @@
 <div class="row course" id="course_{{$index}}" style="margin:0">
-    <x-input.text id="courses[{{$index}}][name]"
+    <x-input.textarea id="courses[{{$index}}][name]"
                     l=5
                     text="Kurzus neve"
-                    value="{{ $value ? $value['name'] ?? '' : '' }}"
-                    required />
-    <x-input.text id="courses[{{$index}}][code]{{ $index }}"
+                    required >{{ $value ? $value['name'] ?? '' : '' }}</x-input.textarea>
+    <x-input.textarea id="courses[{{$index}}][code]{{ $index }}"
                     l=3
                     text="Kurzus kódja"
-                    value="{{ $value ? $value['code'] ?? '' : '' }}"
-                    required />
+                    required >{{ $value ? $value['code'] ?? '' : '' }}</x-input.textarea>
     <x-input.text id="courses[{{$index}}][grade]"
                     l=3 s=11
                     type="number"
                     min="1"
                     max="5"
                     text="Jegy"
-                    value="{{ $value ? $value['grade'] ?? '' : '' }}"
+                    :value="($value ? $value['grade'] ?? '' : '')"
                     helper="(ha ismert)" />
     <x-input.button type="button" s="1" class="right red" floating icon="delete" onclick="removeCourse({{$index}})"/>
 </div>

--- a/resources/views/secretariat/evaluation-form/courses.blade.php
+++ b/resources/views/secretariat/evaluation-form/courses.blade.php
@@ -14,7 +14,7 @@
         A Collegiumból elbocsátható, aki a Collegiumban felvett óráját nem teljesítette.
     </blockquote>
     <div class="row">
-        <x-input.text l=10 id="courses_note" :value="$evaluation?->courses_note" text="Megjegyzés, helyesbítés"/>
+        <x-input.textarea l=10 id="courses_note" text="Megjegyzés, helyesbítés">{{ $evaluation?->courses_note }}</x-input.textarea>
         <x-input.button l=2 class="right" text="general.save" />
     </div>
 </form>

--- a/resources/views/secretariat/evaluation-form/feedback.blade.php
+++ b/resources/views/secretariat/evaluation-form/feedback.blade.php
@@ -7,7 +7,7 @@
     @csrf
     <div class="row">
         <input type="hidden" name="section" value="feedback"/>
-        <x-input.textarea id="feedback" :value="$evaluation?->feedback" text="Visszajelzés..." style="height:100px" />
+        <x-input.textarea id="feedback" text="Visszajelzés..." style="height:100px" >{{$evaluation?->feedback}}</x-input.textarea>
         <x-input.checkbox id="anonymous_feedback" s=10 text="Névtelen visszajelzés" />
         <x-input.button s=2 class="right" text="Küldés" />
     </div>

--- a/resources/views/secretariat/evaluation-form/general_assembly_attendance.blade.php
+++ b/resources/views/secretariat/evaluation-form/general_assembly_attendance.blade.php
@@ -36,8 +36,8 @@
     @csrf
     <div class="row">
         <input type="hidden" name="section" value="general_assembly"/>
-        <x-input.text l=10 id="general_assembly_note" :value="$evaluation?->general_assembly_note"
-                      text="Megjegyzés, helyesbítés, igazolt hiányzás"/>
+        <x-input.textarea l=10 id="general_assembly_note"
+                      text="Megjegyzés, helyesbítés, igazolt hiányzás">{{ $evaluation?->general_assembly_note }}</x-input.textarea>
         <x-input.button l=2 class="right" text="general.save"/>
     </div>
 </form>

--- a/resources/views/secretariat/evaluation-form/status_update.blade.php
+++ b/resources/views/secretariat/evaluation-form/status_update.blade.php
@@ -33,10 +33,9 @@
                     :value="$evaluation?->next_status"
                     :formatter="function($o) { return __('user.'.$o); }"
                     placeholder="Tagsági státusz"/>
-                <x-input.text xl=6 id="next_status_note"
-                    :value="$evaluation?->next_status_note"
+                <x-input.textarea xl=6 id="next_status_note"
                     placeholder="Rövid megjegyzés: BB/Erasmus/két képzés között/stb."
-                    maxlength="20"/>
+                    maxlength="20">{{ $evaluation?->next_status_note }}</x-input.textarea>
                 <x-input.checkbox s=12 id="will_write_request"
                     :checked="$evaluation?->will_write_request ?? false"
                     text="Írok kérvényt." />

--- a/resources/views/student-council/communication-committee/edit.blade.php
+++ b/resources/views/student-council/communication-committee/edit.blade.php
@@ -31,9 +31,9 @@
                     <input type="hidden" name="id" value="{{$epistola->id}}">
                     @endif
                     <div class="row">
-                        <x-input.text id="title" :value="($epistola ? $epistola->title : null)" text="Cím*" required/>
-                        <x-input.text id="subtitle" :value="($epistola ? $epistola->subtitle : null)" text="Alcím*" required/>
-                        <x-input.textarea id="description" :value="($epistola ? $epistola->description : null)" text="Leírás*" required/>
+                        <x-input.textarea id="title" text="Cím*" required>{{ $epistola ? $epistola->title : null }}</x-input.textarea>
+                        <x-input.textarea id="subtitle" text="Alcím*" required>{{ $epistola ? $epistola->subtitle : null }}</x-input.textarea>
+                        <x-input.textarea id="description" text="Leírás*" required>{{ $epistola ? $epistola->description : null }}</x-input.textarea>
                         <div class="col s12">
                         <blockquote>
                             Formázásra a
@@ -48,20 +48,20 @@
                         <x-input.datepicker l=5 id="end_date" :value="($epistola && $epistola->end_date != null ? $epistola->end_date->format('Y-m-d') : null)" text="Esemény vége" />
                     </div>
                     <div class="row">
-                        <x-input.text l=6 id="details_name_1" :value="($epistola ? $epistola->details_name_1 : null)" text="További infó neve" />
-                        <x-input.text l=6 id="details_url_1" type="url" :value="($epistola ? $epistola->details_url_1 : null)" text="További infó url" />
+                        <x-input.textarea l=6 id="details_name_1" text="További infó neve" >{{ $epistola ? $epistola->details_name_1 : null }}</x-input.textarea>
+                        <x-input.textarea l=6 id="details_url_1" type="url" text="További infó url">{{ $epistola ? $epistola->details_url_1 : null }}</x-input.textarea>
                     </div>
                     <div class="row">
-                        <x-input.text l=6 id="details_name_2" :value="($epistola ? $epistola->details_name_2 : null)" text="További infó neve" />
-                        <x-input.text l=6 id="details_url_2" type="url" :value="($epistola ? $epistola->details_url_2 : null)" text="További infó url" />
+                        <x-input.textarea l=6 id="details_name_2" text="További infó neve">{{ $epistola ? $epistola->details_name_2 : null }}</x-input.textarea>
+                        <x-input.textarea l=6 id="details_url_2" type="url" text="További infó url">{{ $epistola ? $epistola->details_url_2 : null }}</x-input.textarea>
                     </div>
                     <div class="row">
-                        <x-input.text l=6 id="deadline_name" :value="($epistola ? $epistola->deadline_name : null)" text="Határidő neve" />
+                        <x-input.textarea l=6 id="deadline_name" text="Határidő neve">{{ $epistola ? $epistola->deadline_name : null }}</x-input.textarea>
                         <x-input.datepicker l=6 id="deadline_date" :value="($epistola && $epistola->deadline_date != null ? $epistola->deadline_date->format('Y-m-d') : null)" text="Határidő" />
                     </div>
                     <div class="row">
                         <x-input.datepicker l=6 id="date_for_sorting" :value="($epistola ? $epistola->date_for_sorting : null)" text="Dátum rendezéshez"/>
-                        <x-input.text l=6 id="category" :value="($epistola ? $epistola->category : null)" text="Kategória"/>
+                        <x-input.textarea l=6 id="category" text="Kategória">{{ $epistola ? $epistola->category : null }}</x-input.textarea>
                     </div>
                     <div class="row">
                         <div class="col l6 file-field">
@@ -71,7 +71,7 @@
                                 <blockquote>{{$message}}</blockquote>
                             @enderror
                         </div>
-                        <x-input.text l=6 id="picture_path" type="url" :value="($epistola ? $epistola->picture_path : null)" text="Vagy kép linkje" />
+                        <x-input.textarea l=6 id="picture_path" type="url" text="Vagy kép linkje" >{{ $epistola ? $epistola->picture_path : null }}</x-input.textarea>
                         @if($epistola && $epistola->picture_path)
                         <img src="{{$epistola->picture_path}}" style="width: 100%">
                         @endif

--- a/resources/views/student-council/mr-and-miss/vote.blade.php
+++ b/resources/views/student-council/mr-and-miss/vote.blade.php
@@ -22,7 +22,7 @@
                     </p>
                     @endcan
                     <p>
-                        Külön tudtok szavazni a Mr, a Miss, illetve az egyéni kategóriákban. Lehetőleg a keresők segítségével válasszátok ki a jelölteteket, azonban ha nem találjátok az illetőt a rendszerben, a sor végén található gombbal tudtok szabad kezes bevitelre váltani. 
+                        Külön tudtok szavazni a Mr, a Miss, illetve az egyéni kategóriákban. Lehetőleg a keresők segítségével válasszátok ki a jelölteteket, azonban ha nem találjátok az illetőt a rendszerben, a sor végén található gombbal tudtok szabad kezes bevitelre váltani.
                         A határidőig bárhányszor módosíthatjátok a szavazatokat.
                     </p>
                     <blockquote>

--- a/resources/views/user/educational-information.blade.php
+++ b/resources/views/user/educational-information.blade.php
@@ -1,9 +1,8 @@
 <form method="POST" action="{{ route('users.update.educational', ['user' => $user]) }}">
     @csrf
     <div class="row">
-        <x-input.text id="high_school" text="user.high_school"
-                      :value="$user->educationalInformation?->high_school"
-                      required/>
+        <x-input.textarea id="high_school" text="user.high_school"
+                      required>{{ $user->educationalInformation?->high_school }}</x-input.textarea>
         <x-input.text s=12 m=6 id="year_of_graduation" text="user.year_of_graduation" type='number' min="1895"
                       :max="date('Y')"
                       :value="$user->educationalInformation?->year_of_graduation"
@@ -15,15 +14,13 @@
                           required/>
         @else
             <x-input.text s=12 m=6 id='year_of_acceptance' text='Collegiumi felvételi éve' type='number'
-                          :value="date('Y')" disabled/>
+                :value="date('Y')" disabled/>
             <input type="hidden" name="year_of_acceptance" value="{{date('Y')}}"/>
         @endif
-        <x-input.text s=6 id="neptun" text="user.neptun"
-                      :value="$user->educationalInformation?->neptun"
-                      required/>
-        <x-input.text s=6 id='educational-email' text='user.educational-email' name="email"
-                      :value="$user->educationalInformation?->email"
-                      required helper="lehetőleg @student.elte.hu-s"/>
+        <x-input.textarea s=6 id="neptun" text="user.neptun"
+                      required>{{ $user->educationalInformation?->neptun }}</x-input.textarea>
+        <x-input.textarea s=6 id='educational-email' text='user.educational-email' name="email"
+                      required helper="lehetőleg @student.elte.hu-s">{{ $user->educationalInformation?->email }}</x-input.textarea>
 
         <div class="input-field col s12 m6">
             <p style="margin-bottom:10px"><label style="font-size: 1em">@lang('user.faculty')</label></p>
@@ -69,12 +66,10 @@
     @if(\Route::current()->getName() != 'application')
     <x-input.textarea
             id='research_topics'
-            text='user.research_topics'
-            :value="$user->educationalInformation?->research_topics" />
+            text='user.research_topics'>{{ $user->educationalInformation?->research_topics }}</x-input.textarea>
     <x-input.textarea
         id='extra_information'
-        text='user.extra_information'
-        :value="$user->educationalInformation?->extra_information" />
+        text='user.extra_information'>{{$user->educationalInformation?->extra_information}}</x-input.textarea>
     @endif
     <div class="row" style="margin: 0">
             <x-input.button class="right" text="general.save" />

--- a/resources/views/user/study-line-selector.blade.php
+++ b/resources/views/user/study-line-selector.blade.php
@@ -13,8 +13,7 @@
         <x-input.textarea id="study_lines[{{ $index }}][minor]"
                     xl=4 s=6
                     text="user.study_line_minor"
-                    :value="$value?->minor"
-		    helper="Nem kötelező"
+		            helper="Nem kötelező"
                     >{{ $value?->minor }}</x-input.textarea>
         <x-input.select id="study_lines[{{ $index }}][start]"
                     xl=6 s=6

--- a/resources/views/user/study-line-selector.blade.php
+++ b/resources/views/user/study-line-selector.blade.php
@@ -1,22 +1,21 @@
 <div class="study_line" id="study_line_{{$index}}">
     <div class="row" style="margin:0">
-        <x-input.text id="study_lines[{{ $index }}][name]"
+        <x-input.textarea id="study_lines[{{ $index }}][name]"
                         xl=6
                         text="user.study_line"
-                        :value="$value?->name"
-                        required />
+                        required>{{ $value?->name }}</x-input.textarea>
         <x-input.select id="study_lines[{{ $index }}][level]"
                         xl=2 s=6
                         text="user.study_line_level"
                         :value="$value?->type"
                         :elements="App\View\Components\Input\Select::convertArray(\App\Models\StudyLine::TYPES)"
                         required />
-        <x-input.text id="study_lines[{{ $index }}][minor]"
+        <x-input.textarea id="study_lines[{{ $index }}][minor]"
                     xl=4 s=6
                     text="user.study_line_minor"
                     :value="$value?->minor"
 		    helper="Nem kötelező"
-                    />
+                    >{{ $value?->minor }}</x-input.textarea>
         <x-input.select id="study_lines[{{ $index }}][start]"
                     xl=6 s=6
                     text="user.study_line_start"


### PR DESCRIPTION
There have been multiple issues with characters being escaped incorrectly. Check #28

It's better and easier to use textareas if someone needs to show previous user input since it is much more established how one can escape HTML as simple text on the page in PHP / Laravel compared to escaping inside of an attribute.
`x-input.textarea` has been also reworked to have a similar interface to `x-input.text` and also to use slots instead of attributes to show values input by the user (https://laravel.com/docs/10.x/blade#slots).

This PR should fix #28.