### PR TITLE
Improve light/dark mode handling

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -44,11 +44,6 @@ class HomeController extends Controller
         ]);
     }
 
-    public function colorMode($mode)
-    {
-        return response('ok')->cookie('theme', $mode, config('app.colormode_cookie_lifespan'));
-    }
-
     public function welcome()
     {
         if (Auth::user()) {

--- a/config/app.php
+++ b/config/app.php
@@ -2,12 +2,6 @@
 
 return [
 
-    'colormode' => [
-        'light',
-        'dark',
-    ],
-    'colormode_cookie_lifespan' => 960000,
-
     /*
     |--------------------------------------------------------------------------
     | Application Name

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -62,7 +62,8 @@
 </head>
 
 <div class="preloader"></div>
-<body class="{{ Cookie::get('theme') }}">
+<body>
+    <script>document.body.classList.add(localStorage.getItem('themeMode') || 'light');</script>
     <header>
         @include('layouts.navbar')
     </header>
@@ -89,19 +90,11 @@
             $('select').formSelect();
         });
         function toggleColorMode() {
-            var mode = (localStorage.getItem('mode') || 'dark') === 'dark' ? 'light' : 'dark';
-            localStorage.setItem('mode', mode);
-            if(localStorage.getItem('mode') === 'dark') {
-                document.querySelector('body').classList.add('dark');
-            } else {
-                document.querySelector('body').classList.remove('dark');
-            }
-
-            // Save as cookie
-            $.ajax({
-                type: "POST",
-                url: "{{ route('set-color-mode', [':mode']) }}".replace(':mode', mode),
-            });
+            const oldThemeMode = localStorage.getItem('themeMode') || 'light'; // default is light mode
+            const newThemeMode = oldThemeMode === 'dark' ? 'light' : 'dark';
+            localStorage.setItem('themeMode', newThemeMode);
+            document.body.classList.remove(oldThemeMode);
+            document.body.classList.add(newThemeMode);
         }
 
         // for our custom arrow dropdowns

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -20,7 +20,8 @@
     @endif
 </head>
 
-<body class="{{ Cookie::get('theme') }}">
+<body>
+    <script>document.body.classList.add(localStorage.getItem('themeMode') || 'light');</script>
     @if (Route::has('login'))
     <header>
         <div class="navbar-fixed">

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,7 +83,6 @@ Route::middleware(['auth', 'log'])->group(function () {
 Route::middleware(['auth', 'log', 'verified'])->group(function () {
     Route::get('/home', [HomeController::class, 'index'])->name('home');
     Route::post('/home/edit', [HomeController::class, 'editNews'])->name('home.edit');
-    Route::post('/color/{mode}', [HomeController::class, 'colorMode'])->name('set-color-mode');
 
     Route::post('/report_bug', [HomeController::class, 'reportBug'])->name('reportbug');
     Route::get('/report_bug', [HomeController::class, 'indexReportBug'])->name('index_reportbug');


### PR DESCRIPTION
Fixed bugs:

- You had to click on the light/dark mode toggle button twice to actually change from light to dark mode for the first time. (E.g. when opening the site in incognito mode.)

Other improvements:

- Exclusively local storage is used to store whether the user prefers light or dark mode: cookies are no longer used.
  - Because of this, the codebase could be simplified.
  - The downside is that the backend no longer gets notified when the user changes their preferences. But this notification is probably not needed anyway.
- The `light` class now gets added/removed from the `<body>` tag when switching between modes. Previously the `light` class would only get added if the page was originally loaded with light mode selected and wouldn't get removed even if the used changed their theme preferences.