### PR TITLE
Align epistola

### DIFF
--- a/app/Http/Controllers/StudentsCouncil/EpistolaController.php
+++ b/app/Http/Controllers/StudentsCouncil/EpistolaController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\StudentsCouncil;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\EpistolaCollegii;
 use Image;

--- a/resources/views/emails/epistola.blade.php
+++ b/resources/views/emails/epistola.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="hu">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -29,6 +29,15 @@ width: 100% !important;
 @viewport{
     zoom: 1.0;
     width: extend-to-zoom;
+}
+.content-cell {
+    hyphens: auto;
+}
+
+@media only screen and (max-width: 700px) {
+    p {
+        text-align: left !important;
+    }
 }
 </style>
 <div style="max-width: 800px;">

--- a/resources/views/emails/epistola.blade.php
+++ b/resources/views/emails/epistola.blade.php
@@ -5,7 +5,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <link type="text/css" rel="stylesheet" href="{{ mix('css/app.css') }}">
 <style>
-.content-cell {
+.article {
     hyphens: auto;
 }
 </style>
@@ -108,7 +108,7 @@
             </table>
             <table class="inner-body" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
-                    <td class="content-cell">
+                    <td class="content-cell article">
                         @foreach ($news as $article)
                             <h2>{{ $loop->iteration }}.<span>{{$article->title }}</span></h2>
                             <h3>{{$article->date_time}}</h3>

--- a/resources/views/emails/epistola.blade.php
+++ b/resources/views/emails/epistola.blade.php
@@ -34,7 +34,7 @@ width: 100% !important;
     hyphens: auto;
 }
 
-@media only screen and (max-width: 700px) {
+@media only screen and (max-width: 35em) {
     p {
         text-align: left !important;
     }

--- a/resources/views/emails/epistola.blade.php
+++ b/resources/views/emails/epistola.blade.php
@@ -4,24 +4,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <link type="text/css" rel="stylesheet" href="{{ mix('css/app.css') }}">
-</head>
-<body>
 <style>
-@media only screen and (max-width: 600px) {
-.inner-body {
-width: 100% !important;
+.content-cell {
+    hyphens: auto;
 }
-
-.footer {
-width: 100% !important;
-}
-}
-
-@media only screen and (max-width: 500px) {
-.button {
-width: 100% !important;
-}
-}
+</style>
+<style>
 @-ms-viewport{
     width: extend-to-zoom;
     zoom: 1.0;
@@ -30,16 +18,29 @@ width: 100% !important;
     zoom: 1.0;
     width: extend-to-zoom;
 }
-.content-cell {
-    hyphens: auto;
+</style>
+<style>
+@media only screen and (max-width: 600px) {
+    .inner-body {
+        width: 100% !important;
+    }
+    .footer {
+        width: 100% !important;
+    }
 }
-
-@media only screen and (max-width: 35em) {
+@media only screen and (max-width: 500px) {
+    .button {
+        width: 100% !important;
+    }
+}
+@media only screen and (max-width:1000px) {
     p {
         text-align: left !important;
     }
 }
 </style>
+</head>
+<body>
 <div style="max-width: 800px;">
 <!--[if (gte mso 9)|(IE)]>
     <table cellspacing="0" cellpadding="0" border="0" width="800"><tr><td>


### PR DESCRIPTION
## Description
Fix alignment issues for epistola email
## Related Issue
#503
## Changes
- allowed hyphenation
- aligned content left for mobiles
## Additional Notes
I was unable to reproduce the issue with emails but I was able to do it on the preview