### PR TITLE
Fixing the log driver for mails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,9 @@ REDIS_PASSWORD=null
 REDIS_PORT=6379
 
 MAIL_TEST_ADMIN=example@eotvos.elte.hu
-MAIL_ACTIVE=false
-MAIL_DRIVER=smtp
+MAIL_ACTIVE=true
+MAIL_MAILER=log  # rewrite this to smtp in production
+MAIL_LOG_CHANNEL=mail
 MAIL_HOST=smtp.mailtrap.io
 MAIL_PORT=2525
 MAIL_USERNAME=null

--- a/config/logging.php
+++ b/config/logging.php
@@ -105,6 +105,12 @@ return [
             'level' => 'debug',
         ],
 
+        'mail' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/mails.log'),
+            'level' => 'debug',
+        ],
+
         'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,

--- a/config/mail.php
+++ b/config/mail.php
@@ -3,7 +3,7 @@
 return [
 
     // Set to true, if you wish to send mails on triggers.
-    'active' => env('MAIL_ACTIVE', false),
+    'active' => env('MAIL_ACTIVE', true),
 
     // Test mail to seed the admin user with.
     'test_mail' => env('MAIL_TEST_ADMIN', 'example@uran.hu'),
@@ -19,14 +19,14 @@ return [
     |
     | Laravel supports both SMTP and PHP's "mail" function as drivers for the
     | sending of e-mail. You may specify which one you're using throughout
-    | your application here. By default, Laravel is setup for SMTP mail.
+    | your application here.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses",
     |            "postmark", "log", "array"
     |
     */
 
-    'driver' => 'smtp',
+    'driver' => env('MAIL_MAILER', 'log'),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
     <server name="APP_ENV" value="testing"/>
     <server name="BCRYPT_ROUNDS" value="4"/>
     <server name="CACHE_DRIVER" value="array"/>
-    <server name="MAIL_DRIVER" value="array"/>
+    <server name="MAIL_MAILER" value="array"/>
     <server name="QUEUE_CONNECTION" value="sync"/>
     <server name="SESSION_DRIVER" value="array"/>
   </php>


### PR DESCRIPTION
Setting the `log` driver for mails did not have any effect; this PR fixes that. It also makes logging the default in `.env.example`.

Mails are written into a separate log file called `mails.log`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled mail functionality by default for easier testing and logging.
  
- **Configuration Updates**
  - Updated mail settings to use a log mailer by default, with instructions to switch to SMTP in production.
  - Added logging configuration for mail, including log path and level.
  
- **Testing Enhancements**
  - Updated PHPUnit configuration to reflect new mailer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->