### PR TITLE
filter last 2 general assemblies for new students

### DIFF
--- a/app/Models/GeneralAssemblies/GeneralAssembly.php
+++ b/app/Models/GeneralAssemblies/GeneralAssembly.php
@@ -3,6 +3,7 @@
 namespace App\Models\GeneralAssemblies;
 
 use App\Enums\PresenceType;
+use App\Models\EducationalInformation;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -147,7 +148,12 @@ class GeneralAssembly extends Model
      */
     public static function requirementsPassed(User $user): bool
     {
-        $lastAssemblies = GeneralAssembly::all()->sortByDesc('closed_at')->take(2);
+        $year_of_acceptance = $user->educationalInformation->year_of_acceptance;
+        $acceptance_date = now()->setYear($year_of_acceptance)->setMonth(9)->setDay(1);
+        $lastAssemblies = GeneralAssembly::orderBy('closed_at', 'desc')->take(2);
+        if ($acceptance_date > $lastAssemblies->get()[1]->closed_at) { // If the user was accepted after the second last assembly
+            return true;
+        }
         foreach ($lastAssemblies as $assembly) {
             if ($assembly->isAttended($user)) {
                 return true;

--- a/app/Models/GeneralAssemblies/GeneralAssembly.php
+++ b/app/Models/GeneralAssemblies/GeneralAssembly.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 
 use App\Models\GeneralAssemblies\Question;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
@@ -149,10 +150,12 @@ class GeneralAssembly extends Model
     public static function requirementsPassed(User $user): bool
     {
         $year_of_acceptance = $user->educationalInformation->year_of_acceptance;
-        $acceptance_date = now()->setYear($year_of_acceptance)->setMonth(9)->setDay(1);
-        $lastAssemblies = GeneralAssembly::orderBy('closed_at', 'desc')->take(2);
-        if ($lastAssemblies->count() >= 2 && $acceptance_date > $lastAssemblies->get()[1]->closed_at) {
-            // If the user was accepted after the second last assembly
+        $acceptance_date = Carbon::createFromDate($year_of_acceptance, 9, 1);
+
+        $lastAssemblies = GeneralAssembly::orderBy('closed_at', 'desc')->take(2)->get();
+        $secondLastAssembly = $lastAssemblies->count() >= 2 ? $lastAssemblies[1] : null;
+
+        if ($secondLastAssembly && $secondLastAssembly->closed_at < $acceptance_date) {
             return true;
         }
         foreach ($lastAssemblies as $assembly) {

--- a/app/Models/GeneralAssemblies/GeneralAssembly.php
+++ b/app/Models/GeneralAssemblies/GeneralAssembly.php
@@ -151,7 +151,8 @@ class GeneralAssembly extends Model
         $year_of_acceptance = $user->educationalInformation->year_of_acceptance;
         $acceptance_date = now()->setYear($year_of_acceptance)->setMonth(9)->setDay(1);
         $lastAssemblies = GeneralAssembly::orderBy('closed_at', 'desc')->take(2);
-        if ($acceptance_date > $lastAssemblies->get()[1]->closed_at) { // If the user was accepted after the second last assembly
+        if ($lastAssemblies->count() >= 2 && $acceptance_date > $lastAssemblies->get()[1]->closed_at) {
+            // If the user was accepted after the second last assembly
             return true;
         }
         foreach ($lastAssemblies as $assembly) {

--- a/tests/Unit/GeneralAssemblyTest.php
+++ b/tests/Unit/GeneralAssemblyTest.php
@@ -187,5 +187,8 @@ class GeneralAssemblyTest extends TestCase
         $generalAssembly2->presenceChecks()->create();
 
         $this->assertTrue(GeneralAssembly::requirementsPassed($user));
+
+        $generalAssembly->update(['closed_at' => now()->setYear(now()->year)->setMonth(9)->setDay(16)]);
+        $this->assertFalse(GeneralAssembly::requirementsPassed($user));
     }
 }

--- a/tests/Unit/GeneralAssemblyTest.php
+++ b/tests/Unit/GeneralAssemblyTest.php
@@ -168,6 +168,9 @@ class GeneralAssemblyTest extends TestCase
         $this->assertNotNull($excused->first()->pivot->comment); // Check if excuse reason is set
     }
 
+    /**
+     * @return void
+     */
     public function test_new_students_pass_requirements(): void
     {
         $user = User::factory()->create(['verified' => true]);

--- a/tests/Unit/GeneralAssemblyTest.php
+++ b/tests/Unit/GeneralAssemblyTest.php
@@ -7,6 +7,7 @@ use App\Models\SemesterStatus;
 use App\Models\User;
 use App\Models\GeneralAssemblies\Question;
 use App\Models\GeneralAssemblies\GeneralAssembly;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -174,14 +175,10 @@ class GeneralAssemblyTest extends TestCase
     public function test_new_students_pass_requirements(): void
     {
         $user = User::factory()->create(['verified' => true]);
-        $user->educationalInformation()->save(EducationalInformation::factory()->make());
-        $user->educationalInformation->update(['year_of_acceptance' => now()->year]);
+        EducationalInformation::factory()->create(['user_id' => $user->id, 'year_of_acceptance' => now()->year]);
 
-        $generalAssembly = GeneralAssembly::factory()->create();
-        $generalAssembly2 = GeneralAssembly::factory()->create();
-
-        $generalAssembly->update(['closed_at' => now()->setYear(now()->year)->setMonth(2)->setDay(15)]);
-        $generalAssembly2->update(['closed_at' => now()->setYear(now()->year)->setMonth(9)->setDay(15)]);
+        $generalAssembly = GeneralAssembly::factory()->create(['closed_at' => Carbon::createFromDate(now()->year, 2, 15)]);
+        $generalAssembly2 = GeneralAssembly::factory()->create(['closed_at' => Carbon::createFromDate(now()->year, 9, 15)]);
 
         $generalAssembly->presenceChecks()->create();
         $generalAssembly2->presenceChecks()->create();


### PR DESCRIPTION
Filter the last 2 general assemblies for freshmen as they are not expected to join the general assemblies before they joined.

If the date of acceptance (September 1, the year of acceptance) is later than the second last general assembly, then the user automatically passed the requirements.

Closes #416 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the requirements check for general assemblies to include logic for new students based on their acceptance date and educational information.

- **Tests**
  - Added a new test to verify that new students meet the requirements for general assemblies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->