### PR TITLE
add permission for the scientific vice president to change users' statuses

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -357,7 +357,7 @@ class UserPolicy
         if (!$target->isCollegist()) {
             return false;
         }
-        if ($user->hasRole(Role::SECRETARY)) {
+        if ($user->hasRole(Role::SECRETARY) || $user->hasRole([Role::STUDENT_COUNCIL => Role::SCIENCE_VICE_PRESIDENT])) {
             return true;
         }
         return $user->roleWorkshops->intersect($target->workshops)->count() > 0;


### PR DESCRIPTION
Closes #511 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded user role permissions to include `Student Council` and `Science Vice President` for status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->