### PR TITLE
listPrintAccountHistory: optimize query

### DIFF
--- a/app/Http/Controllers/Dormitory/PrintController.php
+++ b/app/Http/Controllers/Dormitory/PrintController.php
@@ -227,13 +227,11 @@ class PrintController extends Controller
     {
         $this->authorize('viewAny', PrintJob::class);
 
-        $columns = ['user.name', 'balance_change', 'free_page_change', 'deadline_change', 'modifier.name', 'modified_at'];
+        $columns = ['user_name', 'balance_change', 'free_page_change', 'deadline_change', 'modifier_name', 'modified_at'];
         $paginator = TabulatorPaginator::from(
             PrintAccountHistory::join('users as user', 'user.id', '=', 'user_id')
                 ->join('users as modifier', 'modifier.id', '=', 'modified_by')
-                ->select('print_account_history.*')
-                ->with('user')
-                ->with('modifier')
+                ->select(['user.name as user_name', 'balance_change', 'free_page_change', 'deadline_change', 'modifier.name as modifier_name', 'modified_at'])
         )->sortable($columns)
             ->filterable($columns)
             ->paginate();

--- a/resources/views/dormitory/print/manage/account_history.blade.php
+++ b/resources/views/dormitory/print/manage/account_history.blade.php
@@ -14,7 +14,7 @@ $(document).ready(function() {
         columns: [
             {
                 title: "Felhasználó",
-                field: "user.name",
+                field: "user_name",
                 sorter: "string",
                 headerFilter: 'input',
                 minWidth:200
@@ -39,7 +39,7 @@ $(document).ready(function() {
             },
             {
                 title: "Módosító",
-                field: "modifier.name",
+                field: "modifier_name",
                 sorter: "string",
                 headerFilter: 'input',
                 minWidth:180


### PR DESCRIPTION
## Description
Optimize the SQL queries generated by `listPrintAccountHistory()`. They have been reported to take very long.
## Related Issue
Closes #536. @horcsinbalint described this solution in that issue.
## Changes
- Some variables have been renamed. The solution didn't work without these renames.
- We got rid of `.with(...)` calls. These created queries containing `user.id IN (...long list of user IDs here...)`. These might have been the culprit behind the low performance, but we are not sure: I have tested both the old and the new code with 5000 unique users and 5000 history entries and I had no performance issues with either code versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected column names in the print account history to ensure proper display of user and modifier names.

- **Refactor**
  - Updated query and view logic to use alias names for improved code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->