### PR TITLE
Quick bugfixes for anonymous questions

### DIFF
--- a/app/Exports/UsersSheets/AnonymousQuestionsExport.php
+++ b/app/Exports/UsersSheets/AnonymousQuestionsExport.php
@@ -53,7 +53,6 @@ class AnonymousQuestionsExport implements FromCollection, WithMapping, WithHeadi
     public function headings(): array
     {
         return array_merge([
-            __('general.id'),
             __('general.semester'),
             __('user.year_of_acceptance')
         ], $this->semester->questions()->orderBy('id')->pluck('title')->all());

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -134,7 +134,8 @@ class AnonymousQuestionController extends Controller
     {
         $this->authorize('is-collegist');
 
-        $validator = Validator::make($request->all(),
+        $validator = Validator::make(
+            $request->all(),
             $semester->questionsNotAnsweredBy(user())
                      ->flatMap(fn ($q) => $q->validationRules())
                      ->all()
@@ -150,7 +151,7 @@ class AnonymousQuestionController extends Controller
 
         $validatedData = $validator->validated();
 
-        DB::transaction(function() use ($validatedData, $semester) {
+        DB::transaction(function () use ($validatedData, $semester) {
             // Since answer sheets are anonymous,
             // we cannot append new answers to the previous sheet (if any);
             // we have to create a new one.

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -134,36 +134,49 @@ class AnonymousQuestionController extends Controller
     {
         $this->authorize('is-collegist');
 
-        $validatedData = $request->validate(
+        $validator = Validator::make($request->all(),
             $semester->questionsNotAnsweredBy(user())
                      ->flatMap(fn ($q) => $q->validationRules())
                      ->all()
         );
 
-        // Since answer sheets are anonymous,
-        // we cannot append new answers to the previous sheet (if any);
-        // we have to create a new one.
-        $answerSheet = AnswerSheet::createForCurrentUser($semester);
-
-        foreach($semester->questionsNotAnsweredBy(user()) as $question) {
-            // validation ensures we have answers
-            // to all of these questions
-            $answer = $validatedData[$question->formKey()];
-            if ($question->has_long_answers) {
-                $question->storeAnswers(user(), $answer, $answerSheet);
-            } elseif ($question->isMultipleChoice()) {
-                $options = array_map(
-                    function (int $id) {return QuestionOption::find($id);},
-                    $answer
-                );
-                $question->storeAnswers(user(), $options, $answerSheet);
-            } else {
-                $option = QuestionOption::find($answer);
-                $question->storeAnswers(user(), $option, $answerSheet);
-            }
+        // redirect to the correct section
+        // we will ignore the 'section' field for now and hard-code it
+        if ($validator->fails()) {
+            return back()->withErrors($validator)
+                ->with('section', 'anonymous_questions')
+                ->withInput();
         }
 
-        return back()->with('message', __('general.successful_modification'))->with('section', $request->section);
+        $validatedData = $validator->validated();
+
+        DB::transaction(function() use ($validatedData, $semester) {
+            // Since answer sheets are anonymous,
+            // we cannot append new answers to the previous sheet (if any);
+            // we have to create a new one.
+            $answerSheet = AnswerSheet::createForCurrentUser($semester);
+
+            foreach($semester->questionsNotAnsweredBy(user()) as $question) {
+                // validation ensures we have answers
+                // to all of these questions
+                $answer = $validatedData[$question->formKey()];
+                if ($question->has_long_answers) {
+                    $question->storeAnswers(user(), $answer, $answerSheet);
+                } elseif ($question->isMultipleChoice()) {
+                    $options = array_map(
+                        function (int $id) {return QuestionOption::find($id);},
+                        $answer
+                    );
+                    $question->storeAnswers(user(), $options, $answerSheet);
+                } else {
+                    $option = QuestionOption::find($answer);
+                    $question->storeAnswers(user(), $option, $answerSheet);
+                }
+            }
+        });
+
+        // we will ignore the 'section' field for now and hard-code this
+        return back()->with('message', __('general.successful_modification'))->with('section', 'anonymous_questions');
     }
 
     /**

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -264,7 +264,11 @@ class Question extends Model
         if ($this->has_long_answers) {
             $rules[$key] = 'required|string';
         } elseif ($this->isMultipleChoice()) {
-            $rules[$key] = 'required|array';
+            $rules[$key] = [
+                'required',
+                'array',
+                'max:' . $this->max_options
+            ];
             $rules[$key . '.*'] = Rule::in($this->options->map(
                 function (QuestionOption $option) {return $option->id;}
             ));

--- a/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
+++ b/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
@@ -3,6 +3,7 @@
 </blockquote>
 <form method="POST" action="{{ route('anonymous_questions.store_answer_sheet', App\Models\Semester::current()) }}">
     @csrf
+    <input type="hidden" name="section" value="anonymous_questions">
 
     @php
         // We only take the questions that have been answered.
@@ -27,9 +28,12 @@
                 @else
                 @foreach($question->options()->get() as $option)
                     @if($question->max_options==1)
-                    <x-input.radio :name="$question->formKey()" value="{{$option->id}}" text="{{$option->title}}" />
+                    <x-input.radio :name="$question->formKey()" value="{{$option->id}}" text="{{$option->title}}"
+                        :checked="old($question->formKey()) == $option->id" />
                     @else
-                    <x-input.checkbox :name="$question->formKey().'[]'" value="{{$option->id}}" text="{{$option->title}}" />
+                    <x-input.checkbox :name="$question->formKey().'[]'" value="{{$option->id}}" text="{{$option->title}}"
+                        :checked="!is_null(old($question->formKey()))
+                                  && in_array($option->id, old($question->formKey()))" />
                     @endif
                 @endforeach
                 @endif

--- a/resources/views/secretariat/evaluation-form/avg.blade.php
+++ b/resources/views/secretariat/evaluation-form/avg.blade.php
@@ -1,7 +1,7 @@
 <form method="POST" action="">
     @csrf
     <blockquote>
-        Ha még nem vagy lezárva minden tárgyból, ne írd be az átlagodat! (Ha lezárnak a beküldési határidő előtt, akkor be tudod majd írni akkor is.)
+        Ha még nem vagy lezárva minden tárgyból, ne írd be az átlagodat! (A beküldési határidőig bármikor beírhatod majd.)
     </blockquote>
     <div class="row">
         <input type="hidden" name="section" value="avg"/>
@@ -12,7 +12,7 @@
         <a href="https://eotvos.elte.hu/collegium/mukodes/szabalyzatok">CTSZK 7. § (4) b.</a>
         A collegiumi tagság automatikusan megszűnik, ha a hallgatónak a tanulmányi átlaga két egymást követő félévben 4,25 alá süllyed<br>
         i. ahol a hagyományos átlagszámítás az érvényes, melybe minden szöveges értékelésű és nullkredites tárgy is beleszámít, illetve a BTK-s és TáTK-s kezelési körben meghirdetett kurzusok esetében az elhagyott tanegység értéke nulla,<br>
-        ii. a hallgató mentesül a 7. § (4) b. rendelkezés alól, amennyiben a műhelyvezető támogatásával a hallgató kérelmezésére kezdeményezett vizsgálat alapján teljesítménye mindkét kérdéses félévben az adott szakon azonos számú aktív félévvel rendelkező hallgatók kreditindexe alapján felállított lista legjobb 10%-ához tartozik
+        ii. a hallgató mentesül a 7. § (4) b. rendelkezés alól, amennyiben a műhelyvezető támogatásával a hallgató kérelmezésére kezdeményezett vizsgálat alapján teljesítménye mindkét kérdéses félévben az adott szakon azonos számú aktív félévvel rendelkező hallgatók kreditindexe alapján felállított lista legjobb 10%-ához tartozik.
     </blockquote>
     <div class="row">
         <x-input.button class="right" text="general.save" />

--- a/resources/views/student-council/anonymous-questions/index_semesters.blade.php
+++ b/resources/views/student-council/anonymous-questions/index_semesters.blade.php
@@ -8,9 +8,13 @@
 
 @section('content')
 
-@foreach(App\Models\Semester::orderBy('year', 'desc')->orderBy('part', 'desc')->get() as $semester)
-<ul class="collapsible" @if(session()->get('section') == $semester->id) class="active" @endif>
-    <li @if(session()->get('section') == $semester->id) class="active" @endif>
+@foreach(App\Models\Semester::allUntilCurrent()
+    ->sortBy(function (App\Models\Semester $semester) {
+        return $semester->getStartDate();
+    })->reverse()
+    as $semester)
+<ul class="collapsible">
+    <li @if($semester->isCurrent()) class="active" @endif>
         <div class="collapsible-header">
                 <b>{{$semester->tag}}</b>
         </div>


### PR DESCRIPTION
Bugfixes for the anonymous questions feature introduced in #542.

- Now, the validator handles if more than `max_options` options are checked for a multiple-choice question.
- After validation errors, all checkboxes were checked and all radio buttons were unchecked. Now, they hold their values.
- After validation errors, the redirection passes the appropriate section to the session variables, so the user need not scroll down again.
- Creation of answer sheets is now wrapped into a `DB::transaction`.
- The header of the Excel sheet still had the _id_ field.
- Integrated #526 here (the text is now `A beküldési határidőig bármikor beírhatod majd.`).
- On the admin page,
  - future semesters are no longer displayed so as to avoid confusion;
  - the card for the current semester is automatically set active.

Huge thanks if you can take a look at them before deployment.