### PR TITLE
Suggestions to use periodicEvents for AnonymousQuestions

### DIFF
--- a/app/Exports/UsersSheets/AnonymousQuestionsExport.php
+++ b/app/Exports/UsersSheets/AnonymousQuestionsExport.php
@@ -53,7 +53,6 @@ class AnonymousQuestionsExport implements FromCollection, WithMapping, WithHeadi
     public function headings(): array
     {
         return array_merge([
-            __('general.id'),
             __('general.semester'),
             __('user.year_of_acceptance')
         ], $this->semester->questions()->orderBy('id')->pluck('title')->all());

--- a/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
+++ b/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
@@ -57,7 +57,7 @@ class SemesterEvaluationController extends Controller
 
         $this->updatePeriodicEvent($semester, $startDate, $endDate);
 
-        // setting start and end dates of questions
+        // updating start and end dates of questions
         $semester->questions()->update([
             'opened_at' => $startDate,
             'closed_at' => $endDate

--- a/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
+++ b/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
@@ -136,6 +136,9 @@ class SemesterEvaluationController extends Controller
         $this->authorize('fillOrManage', SemesterEvaluation::class);
 
         return view('secretariat.evaluation-form.app', [
+            // let the current semester be found based on the periodic event itself
+            // we can safely assume it is not null
+            'semester' => app(\App\Http\Controllers\Secretariat\SemesterEvaluationController::class)->semester(),
             'phd' => user()->educationalInformation->studyLines()->currentlyEnrolled()->where('type', 'phd')->exists(),
             'user' => user(),
             'faculties' => Faculty::all(),

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -48,8 +48,9 @@ class AnonymousQuestionController extends Controller
     public function canAddQuestionTo(Semester $semester): bool
     {
         // true for future, false for past semesters
-        if (!$semester->isCurrent()) return !$semester->isClosed();
-        else {
+        if (!$semester->isCurrent()) {
+            return !$semester->isClosed();
+        } else {
             $endDate = $this->getEndDate();
             return is_null($endDate) || !$endDate->isPast();
         }

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -55,7 +55,7 @@ class AnonymousQuestionController extends Controller
             $endDate = $this->getEndDate();
             return is_null($endDate)
                 || $this->semester()->id == $semester->id && !$endDate->isPast();
-                                         // ^ it must be the semester belonging to the periodic event
+            // ^ it must be the semester belonging to the periodic event
         }
     }
 

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -43,13 +43,26 @@ class AnonymousQuestionController extends Controller
     }
 
     /**
+     * Whether we allow a semester to be added questions.
+     */
+    public function canAddQuestionTo(Semester $semester): bool
+    {
+        // true for future, false for past semesters
+        if (!$semester->isCurrent()) return !$semester->isClosed();
+        else {
+            $endDate = $this->getEndDate();
+            return is_null($endDate) || !$endDate->isPast();
+        }
+    }
+
+    /**
      * Returns the 'new question' page.
      */
     public function create(Semester $semester)
     {
         $this->authorize('administer', AnswerSheet::class);
 
-        if ($semester->isClosed() && !$semester->isCurrent()) {
+        if (!$this->canAddQuestionTo($semester)) {
             abort(403, "tried to add a question to a closed semester");
         }
         return view('student-council.anonymous-questions.create', [
@@ -65,7 +78,7 @@ class AnonymousQuestionController extends Controller
         $this->authorize('administer', AnswerSheet::class);
 
         // we need this; the current semester might also be closed
-        if ($semester->isClosed() && !$semester->isCurrent()) {
+        if (!$this->canAddQuestionTo($semester)) {
             abort(403, "tried to add a question to a closed semester");
         }
 

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -44,29 +44,13 @@ class AnonymousQuestionController extends Controller
     }
 
     /**
-     * Whether we allow a semester to be added questions.
-     */
-    public function canAddQuestionTo(Semester $semester): bool
-    {
-        // true for future, false for past semesters
-        if (!$semester->isCurrent()) {
-            return !$semester->isClosed();
-        } else {
-            $endDate = $this->getEndDate();
-            return is_null($endDate)
-                || $this->semester()->id == $semester->id && !$endDate->isPast();
-            // ^ it must be the semester belonging to the periodic event
-        }
-    }
-
-    /**
      * Returns the 'new question' page.
      */
     public function create(Semester $semester)
     {
         $this->authorize('administer', AnswerSheet::class);
 
-        if (!$this->canAddQuestionTo($semester)) {
+        if ($semester->isClosed() && !$semester->isCurrent()) {
             abort(403, "tried to add a question to a closed semester");
         }
         return view('student-council.anonymous-questions.create', [
@@ -82,7 +66,7 @@ class AnonymousQuestionController extends Controller
         $this->authorize('administer', AnswerSheet::class);
 
         // we need this; the current semester might also be closed
-        if (!$this->canAddQuestionTo($semester)) {
+        if ($semester->isClosed() && !$semester->isCurrent()) {
             abort(403, "tried to add a question to a closed semester");
         }
 

--- a/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
+++ b/app/Http/Controllers/StudentsCouncil/AnonymousQuestionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\StudentsCouncil;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -52,7 +53,9 @@ class AnonymousQuestionController extends Controller
             return !$semester->isClosed();
         } else {
             $endDate = $this->getEndDate();
-            return is_null($endDate) || !$endDate->isPast();
+            return is_null($endDate)
+                || $this->semester()->id == $semester->id && !$endDate->isPast();
+                                         // ^ it must be the semester belonging to the periodic event
         }
     }
 

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -187,7 +187,7 @@ class Question extends Model
      * if the user has already answered the question
      * or if a long textual answer is provided for a question which does not support it.
      */
-    public function storeAnswers(User $user, QuestionOption|array|string $answer, ?AnswerSheet $answerSheet = null): void
+    public function storeAnswers(User $user, QuestionOption|array|string|null $answer, ?AnswerSheet $answerSheet = null): void
     {
         // the additional check is needed for the seeder
         if (!$this->isOpen() && (!app()->runningInConsole() || app()->runningUnitTests())) {
@@ -225,7 +225,7 @@ class Question extends Model
                         ]);
                     }
                 }
-            } // else it is a string
+            } // else it is a string or null for a question with long answers
             elseif (!$this->has_long_answers) {
                 throw new Exception("This question does not support long answers");
             } else {
@@ -262,7 +262,7 @@ class Question extends Model
         $key = $this->formKey();
         $rules = [];
         if ($this->has_long_answers) {
-            $rules[$key] = 'required|string';
+            $rules[$key] = 'nullable|string';
         } elseif ($this->isMultipleChoice()) {
             $rules[$key] = [
                 'required',

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -224,7 +224,7 @@ class Semester extends Model
      */
     public function transactions(): HasMany
     {
-        return $this->hasMany(App\Models\Transaction::class, 'semester_id');
+        return $this->hasMany(\App\Models\Transaction::class, 'semester_id');
     }
 
     public function communityServices(): HasMany
@@ -247,7 +247,7 @@ class Semester extends Model
      */
     public function workshopBalances(): HasMany
     {
-        return $this->hasMany(App\Models\WorkshopBalance::class);
+        return $this->hasMany(\App\Models\WorkshopBalance::class);
     }
 
     /**

--- a/app/Utils/HasPeriodicEvent.php
+++ b/app/Utils/HasPeriodicEvent.php
@@ -45,23 +45,6 @@ trait HasPeriodicEvent
     }
 
     /**
-     * Get the PeriodicEvent connected to the controller
-     * and belonging to the given semester
-     * (by default the current one).
-     *
-     * @return PeriodicEvent|null
-     */
-    final public function periodicEventForSemester(?Semester $semester): ?PeriodicEvent
-    {
-        if (is_null($semester)) {
-            $semester = Semester::current();
-        }
-        return PeriodicEvent::where('event_model', $this->underlyingControllerName)
-            ->where('semester_id', $semester->id)
-            ->first();
-    }
-
-    /**
      * Create or update the current PeriodicEvent connected to the model.
      * Make sure the $data is properly validated:
      * @param Semester $semester

--- a/database/migrations/2024_07_11_133614_make_long_answers_nullable.php
+++ b/database/migrations/2024_07_11_133614_make_long_answers_nullable.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_07_11_133614_make_long_answers_nullable.php
+++ b/database/migrations/2024_07_11_133614_make_long_answers_nullable.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('long_answers', function (Blueprint $table) {
+            $table->text('text')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('long_answers')->whereNull('text')->update(['text' => '-']); // a dash
+        Schema::table('long_answers', function (Blueprint $table) {
+            $table->text('text')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/lang/en/anonymous_questions.php
+++ b/resources/lang/en/anonymous_questions.php
@@ -4,6 +4,11 @@ return [
     'all_questions_filled' => 'You have filled all these questions; thank you!',
     'anonymous_questions' => 'Anonymous questions',
     'create_question' => 'Create question',
+    'creation_for_current_only' => 'Creating new questions is allowed only for the semester
+                                    for which the current evaluation form has been created.<br />
+                                    If you cannot create a question,
+                                    simply <a href="/secretariat/evaluation">save the form</a> for the correct semester
+                                    with a future start date.',
     'export' => 'Export',
     'has_long_answers' => 'expects long, written answers',
     'information_text' => "The following questions are going to be used to assess

--- a/resources/lang/hu/anonymous_questions.php
+++ b/resources/lang/hu/anonymous_questions.php
@@ -4,6 +4,12 @@ return [
     'all_questions_filled' => 'Már kitöltötted ezeket a kérdéseket; köszönjük!',
     'anonymous_questions' => 'Anonim visszajelzések',
     'create_question' => 'Kérdés hozzáadása',
+    'creation_for_current_only' => 'Csak ahhoz a szemeszterhez tudsz kérdést létrehozni,
+                                    amihez az aktuális értékelő kérdőív tartozik.<br />
+                                    Ha a rendszer nem enged kérdést létrehozni,
+                                    egyszerűen <a href="/secretariat/evaluation">mentsd el a formot</a>
+                                    a megfelelő félévhez,
+                                    akár egy jövőbeli megnyitási időponttal.',
     'export' => 'Exportálás',
     'has_long_answers' => 'kifejtős',
     'information_text' => "Ezek a visszajelzések a Választmánynak segítenek,

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -125,7 +125,7 @@
                                 {{-- results of anonymous questions --}}
                                 @can('administer', \App\Models\AnonymousQuestions\AnswerSheet::class)
                                 <li>
-                                    <a class="waves-effect" href="{{ route('anonymous_questions.index_semesters') }}">
+                                    <a class="waves-effect" href="{{ route('anonymous_questions.index') }}">
                                         <i class="material-icons left">assessment</i>
                                         @lang('anonymous_questions.anonymous_questions')
                                     </a>

--- a/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
+++ b/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
@@ -2,12 +2,6 @@
     @lang('anonymous_questions.information_text')
 </blockquote>
 
-@php
-// let the current semester be found based on the periodic event itself
-// we can safely assume it is not null
-$semester = app(\App\Http\Controllers\Secretariat\SemesterEvaluationController::class)->semester();
-@endphp
-
 <form method="POST" action="{{ route('anonymous_questions.store_answers', $semester) }}">
     @csrf
     <input type="hidden" name="section" value="anonymous_questions">

--- a/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
+++ b/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
@@ -1,12 +1,19 @@
 <blockquote>
     @lang('anonymous_questions.information_text')
 </blockquote>
-<form method="POST" action="{{ route('anonymous_questions.store_answer_sheet', App\Models\Semester::current()) }}">
+
+@php
+// let the current semester be found based on the periodic event itself
+// we can safely assume it is not null
+$semester = app(\App\Http\Controllers\Secretariat\SemesterEvaluationController::class)->semester();
+@endphp
+
+<form method="POST" action="{{ route('anonymous_questions.store_answers', $semester) }}">
     @csrf
 
     @php
         // We only take the questions that have been answered.
-        $questions = App\Models\Semester::current()->questionsNotAnsweredBy(user());
+        $questions = $semester->questionsNotAnsweredBy(user());
     @endphp
 
     @if ($questions->isEmpty())

--- a/resources/views/student-council/anonymous-questions/create.blade.php
+++ b/resources/views/student-council/anonymous-questions/create.blade.php
@@ -1,8 +1,8 @@
 @extends('layouts.app')
 
 @section('title')
-<a href="{{route('anonymous_questions.index_semesters')}}" class="breadcrumb" style="cursor: pointer">@lang('anonymous_questions.anonymous_questions')</a>
-<a href="{{route('anonymous_questions.index_semesters')}}" class="breadcrumb" style="cursor: pointer">{{ $semester->tag }}</a>
+<a href="{{route('anonymous_questions.index')}}" class="breadcrumb" style="cursor: pointer">@lang('anonymous_questions.anonymous_questions')</a>
+<a href="{{route('anonymous_questions.index')}}" class="breadcrumb" style="cursor: pointer">{{ $semester->tag }}</a>
 <a href="#!" class="breadcrumb">@lang('anonymous_questions.create_question')</a>
 
 @endsection

--- a/resources/views/student-council/anonymous-questions/create.blade.php
+++ b/resources/views/student-council/anonymous-questions/create.blade.php
@@ -2,7 +2,6 @@
 
 @section('title')
 <a href="{{route('anonymous_questions.index')}}" class="breadcrumb" style="cursor: pointer">@lang('anonymous_questions.anonymous_questions')</a>
-<a href="{{route('anonymous_questions.index')}}" class="breadcrumb" style="cursor: pointer">{{ $semester->tag }}</a>
 <a href="#!" class="breadcrumb">@lang('anonymous_questions.create_question')</a>
 
 @endsection
@@ -13,13 +12,13 @@
 <div class="row">
     <div class="col s12">
         <div class="card">
-            <form action="{{route('anonymous_questions.store', ['semester' => $semester])}}" method="POST">
+            <form action="{{route('anonymous_questions.store')}}" method="POST">
                 @csrf
 
                 @include('utils.question_card', ['canHaveLongAnswers' => true])
 
                 <div class="card-action right-align">
-                    <a href="{{route('anonymous_questions.index', $semester)}}" class="waves-effect btn">@lang('general.cancel')</a>
+                    <a href="{{route('anonymous_questions.index')}}" class="waves-effect btn">@lang('general.cancel')</a>
                     <button type="submit" class="waves-effect btn">@lang('general.save')</button>
                 </div>
             </form>

--- a/resources/views/student-council/anonymous-questions/index.blade.php
+++ b/resources/views/student-council/anonymous-questions/index.blade.php
@@ -20,7 +20,7 @@
                     @lang('anonymous_questions.number_of_fillings'):
                     {{$semester->answerSheets->count()}}
                 </b>
-                <x-input.button :href="route('anonymous_questions.export_answer_sheets', $semester)"
+                <x-input.button :href="route('anonymous_questions.export_answers', $semester)"
                     class="right" :text="__('anonymous_questions.export')" />
             </div>
 
@@ -45,7 +45,7 @@
                 @endforeach
             </ul>
 
-            @if(!$semester->isClosed())
+            @if($semester->isCurrent() || !$semester->isClosed())
             <div class="row" style="margin: 0">
                 <x-input.button :href="route('anonymous_questions.create', $semester)"
                         class="right green" :text="__('anonymous_questions.create_question')" />

--- a/resources/views/student-council/anonymous-questions/index.blade.php
+++ b/resources/views/student-council/anonymous-questions/index.blade.php
@@ -5,16 +5,39 @@
 @endsection
 @section('secretariat_module') active @endsection
 
+@php
+// let the current semester be found based on the periodic event itself
+// beware: it might be null
+$periodicEvent = app(\App\Http\Controllers\Secretariat\SemesterEvaluationController::class)->periodicEvent();
+$currentSemester = $periodicEvent?->semester;
+@endphp
 
 @section('content')
+
+
+<div class="row">
+    <div class="col s12">
+        <div class="card">
+            <div class="card-content">
+                <p>@lang('anonymous_questions.creation_for_current_only')</p>
+            </div>
+        </div>
+    </div>
+</div>
 
 @foreach(App\Models\Semester::allUntilCurrent()
     ->sortBy(function (App\Models\Semester $semester) {
         return $semester->getStartDate();
     })->reverse()
     as $semester)
+
+@php
+$isActive = $currentSemester?->id == $semester->id
+            && (!$periodicEvent->endDate()?->isPast() ?? false);
+@endphp
+
 <ul class="collapsible">
-    <li @if($semester->isCurrent()) class="active" @endif>
+    <li @if($isActive) class="active" @endif>
         <div class="collapsible-header">
                 <b>{{$semester->tag}}</b>
         </div>
@@ -49,7 +72,7 @@
                 @endforeach
             </ul>
 
-            @if($semester->isCurrent() || !$semester->isClosed())
+            @if($isActive)
             <div class="row" style="margin: 0">
                 <x-input.button :href="route('anonymous_questions.create', $semester)"
                         class="right green" :text="__('anonymous_questions.create_question')" />

--- a/resources/views/student-council/anonymous-questions/index.blade.php
+++ b/resources/views/student-council/anonymous-questions/index.blade.php
@@ -5,11 +5,6 @@
 @endsection
 @section('secretariat_module') active @endsection
 
-@php
-// let us decide the openness of semesters
-// based on the periodic event itself
-$anonymousQuestionController = app(\App\Http\Controllers\StudentsCouncil\AnonymousQuestionController::class);
-@endphp
 
 @section('content')
 
@@ -54,7 +49,7 @@ $anonymousQuestionController = app(\App\Http\Controllers\StudentsCouncil\Anonymo
                 @endforeach
             </ul>
 
-            @if($anonymousQuestionController->canAddQuestionTo($semester))
+            @if($semester->isCurrent() || !$semester->isClosed())
             <div class="row" style="margin: 0">
                 <x-input.button :href="route('anonymous_questions.create', $semester)"
                         class="right green" :text="__('anonymous_questions.create_question')" />

--- a/resources/views/student-council/anonymous-questions/index.blade.php
+++ b/resources/views/student-council/anonymous-questions/index.blade.php
@@ -5,6 +5,11 @@
 @endsection
 @section('secretariat_module') active @endsection
 
+@php
+// let us decide the openness of semesters
+// based on the periodic event itself
+$anonymousQuestionController = app(\App\Http\Controllers\StudentsCouncil\AnonymousQuestionController::class);
+@endphp
 
 @section('content')
 
@@ -45,7 +50,7 @@
                 @endforeach
             </ul>
 
-            @if($semester->isCurrent() || !$semester->isClosed())
+            @if($anonymousQuestionController->canAddQuestionTo($semester))
             <div class="row" style="margin: 0">
                 <x-input.button :href="route('anonymous_questions.create', $semester)"
                         class="right green" :text="__('anonymous_questions.create_question')" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -287,15 +287,14 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
 
     /** anonymous questions */
     Route::prefix('/anonymous_questions')->name('anonymous_questions.')->group(function () {
-        Route::get('/', [AnonymousQuestionController::class, 'indexSemesters'])->name('index_semesters');
-        Route::get('/{semester}/questions/', [AnonymousQuestionController::class, 'index'])->name('index');
+        Route::get('/', [AnonymousQuestionController::class, 'index'])->name('index');
         Route::get('/{semester}/questions/create', [AnonymousQuestionController::class, 'create'])->name('create');
         Route::post('/{semester}/questions', [AnonymousQuestionController::class, 'store'])->name('store');
         Route::get('/{semester}/questions/{question}', [AnonymousQuestionController::class, 'show'])->name('show')
             ->withoutMiddleware([LogRequests::class])
             ->scopeBindings();
-        Route::post('/{semester}/sheets/', [AnonymousQuestionController::class, 'storeAnswerSheet'])->name('store_answer_sheet')
+        Route::post('/{semester}/sheets/', [AnonymousQuestionController::class, 'storeAnswers'])->name('store_answers')
             ->withoutMiddleware([LogRequests::class]);
-        Route::get('/{semester}/sheets/', [AnonymousQuestionController::class, 'exportAnswerSheets'])->name('export_answer_sheets');
+        Route::get('/{semester}/sheets/', [AnonymousQuestionController::class, 'exportAnswers'])->name('export_answers');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -288,13 +288,10 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
     /** anonymous questions */
     Route::prefix('/anonymous_questions')->name('anonymous_questions.')->group(function () {
         Route::get('/', [AnonymousQuestionController::class, 'index'])->name('index');
-        Route::get('/{semester}/questions/create', [AnonymousQuestionController::class, 'create'])->name('create');
-        Route::post('/{semester}/questions', [AnonymousQuestionController::class, 'store'])->name('store');
-        Route::get('/{semester}/questions/{question}', [AnonymousQuestionController::class, 'show'])->name('show')
-            ->withoutMiddleware([LogRequests::class])
-            ->scopeBindings();
-        Route::post('/{semester}/sheets/', [AnonymousQuestionController::class, 'storeAnswers'])->name('store_answers')
+        Route::get('/questions/create', [AnonymousQuestionController::class, 'create'])->name('create');
+        Route::post('/questions', [AnonymousQuestionController::class, 'store'])->name('store');
+        Route::post('/sheets/', [AnonymousQuestionController::class, 'storeAnswers'])->name('store_answers')
             ->withoutMiddleware([LogRequests::class]);
-        Route::get('/{semester}/sheets/', [AnonymousQuestionController::class, 'exportAnswers'])->name('export_answers');
+        Route::get('/sheets/{semester}', [AnonymousQuestionController::class, 'exportAnswers'])->name('export_answers');
     });
 });


### PR DESCRIPTION
@viktorcsimma I think I know what you found confusing about the periodicEvents.

With PeriodicEvents, you cannot create a question for a previous semester, you can only create and answer a question for the current period (which makes sense to me, but let me know if you don't agree).
When the dates of the semesterEvaluation are set, the semester to which it applies must also be specified. You can use that semester via the periodicEvent which will also define the deadlines for the questions.

Questions for older semesters can still be exported as they are stored for their semesters.

This PR contains how I think the controller should utilise the PeriodicEvents. The other parts of the solution should be modified accordingly.

Feel free to take over this branch or create a new one.

