### PR TITLE
Fixing checkbox not remembering its previous state; as well as too short question titles

### DIFF
--- a/resources/views/components/input/checkbox.blade.php
+++ b/resources/views/components/input/checkbox.blade.php
@@ -8,7 +8,8 @@
             'class' => "filled-in checkbox-color",
             'name' => $id
         ])}}
-        @checked(old($id) || $checked)
+        @checked(in_array($attributes['value'], (old($id)['option'] ?? []))
+                 || $checked)
     >
     <span>{{$label}}</span>
 </label>

--- a/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
+++ b/resources/views/secretariat/evaluation-form/anonymous_questions.blade.php
@@ -31,9 +31,9 @@
                     <x-input.radio :name="$question->formKey()" value="{{$option->id}}" text="{{$option->title}}"
                         :checked="old($question->formKey()) == $option->id" />
                     @else
-                    <x-input.checkbox :name="$question->formKey().'[]'" value="{{$option->id}}" text="{{$option->title}}"
-                        :checked="!is_null(old($question->formKey()))
-                                  && in_array($option->id, old($question->formKey()))" />
+                    <x-input.checkbox :id="$question->formKey()" :name="$question->formKey().'[]'" value="{{$option->id}}" text="{{$option->title}}"
+                        {{-- for some reason, having a custom id changes the structure of old($id) --}}
+                        :checked="in_array($option->id, (old($question->formKey()) ?? []))" />
                     @endif
                 @endforeach
                 @endif

--- a/resources/views/utils/question_card.blade.php
+++ b/resources/views/utils/question_card.blade.php
@@ -9,7 +9,7 @@
 
     <span class="card-title">@lang('voting.new_question')</span>
     <div class="row">
-        <x-input.text s="12" type="text" text="voting.question_title" id="title" maxlength="100" required/>
+        <x-input.text s="12" type="text" text="voting.question_title" id="title" maxlength="250" required/>
     </div>
     <div class="row">
         @livewire('parent-child-form', ['title' => __('voting.options'), 'name' => 'options', 'items' => old('options')])


### PR DESCRIPTION
As the title says.

The solution for the anonymous questions card is not too elegant (probably the custom id causes some complications), but it seems to work for now.