### PR TITLE
Fixing erroneous call which caused the tenant update panel to crash

### DIFF
--- a/resources/views/user/update_tenant_status.blade.php
+++ b/resources/views/user/update_tenant_status.blade.php
@@ -27,7 +27,7 @@
     </div>
 
     @if (
-        App\Http\Controllers\Auth\ApplicationController::getApplicationDeadline() > \Carbon\Carbon::now()
+        app(App\Http\Controllers\Auth\ApplicationController::class)->isActive()
         && user()->isTenant()
         && !user()->isCollegist(alumni: false)
     )


### PR DESCRIPTION
As in the title. It would be pretty urgent, as the tenants who have previously registered cannot login again. Could you check it out and deploy it ASAP?