### PR TITLE
Fixing permission problems with applications

### DIFF
--- a/app/Http/Controllers/Auth/ApplicationController.php
+++ b/app/Http/Controllers/Auth/ApplicationController.php
@@ -163,7 +163,7 @@ class ApplicationController extends Controller
                 $applications->whereIn('workshop_id', $workshops->pluck('id'));
             }
             //hide unfinished
-            if ($authUser->cannot('viewUnfinishedApplications', [User::class])) {
+            if ($authUser->cannot('viewUnfinished', \App\Models\ApplicationForm::class)) {
                 $applications->where(function ($query) {
                     $query->where('status', ApplicationForm::STATUS_SUBMITTED)
                         ->orWhere('status', ApplicationForm::STATUS_CALLED_IN)

--- a/resources/views/auth/application/application.blade.php
+++ b/resources/views/auth/application/application.blade.php
@@ -1,5 +1,5 @@
 {{-- All the application's data for finalization and for the admission committes to show --}}
-@can('viewApplication', $user)
+@can('view', $user->application)
     <div class="card">
         <div class="card-content">
             <div class="row" style="margin-bottom: 0">
@@ -11,7 +11,7 @@
                     @endif
                 </div>
                 <div class="col s12 xl8">
-                    @can('editApplicationStatus', \App\Models\User::class)
+                    @can('editStatus', \App\Models\ApplicationForm::class)
                         @if(!(user()->isAdmin() || $user->application->status != \App\Models\ApplicationForm::STATUS_IN_PROGRESS))
                             <span class="right">
                                 @include('auth.application.status', ['status' => $user->application->status])

--- a/resources/views/auth/application/applications.blade.php
+++ b/resources/views/auth/application/applications.blade.php
@@ -13,7 +13,7 @@
                     <form id="workshop-filter" method="GET" route="{{route('applications')}}">
                         <x-input.select id="workshop" :elements="$workshops" allow-empty :default="$workshop"
                                         text="Műhely"/>
-                        @can('viewUnfinishedApplications', \App\models\User::class)
+                        @can('viewUnfinished', \App\Models\ApplicationForm::class)
                             @foreach (\App\Models\ApplicationForm::STATUSES as $st)
                                 <label>
                                     <input type="radio" name="status" value="{{$st}}"
@@ -22,7 +22,7 @@
                                         style="padding-left: 25px; margin: 5px">@include('auth.application.status', ['status' => $st])</span>
                                 </label>
                             @endforeach
-                        @endif
+                        @endcan
                         <x-input.button type="submit" text="Szűrés"/>
                     </form>
                     <form id="empty-filter" method="GET" route="{{route('application')}}"
@@ -31,10 +31,10 @@
                     </form>
                 </div>
                 <blockquote>
-                    @can('editApplicationStatus', \App\Models\User::class)
+                    @can('editStatus', \App\Models\ApplicationForm::class)
                         <p>A jelentkezők aktuális státusza a jelentkezők számára nem nyilvános.</p>
                     @endcan
-                    @can('finalizeApplicationProcess', \App\Models\User::class)
+                    @can('finalize', \App\Models\ApplicationForm::class)
                         <p>{{$applicationDeadline?->addWeeks(1)?->format('Y. m. d.')}} után lehet a lap alján felvenni a
                             kiválasztott jelentkezőket, ezzel véglegesíteni a felvételit.</p>
                     @endcan
@@ -60,7 +60,7 @@
     @endforeach
     <hr>
     <h6>Összesen: <b class="right">{{$applications->count()}} jelentkező</b></h6>
-    @can('finalizeApplicationProcess', \App\Models\User::class)
+    @can('finalize', \App\Models\ApplicationForm::class)
         @if($applicationDeadline?->addWeeks(1) < now())
             <div class="card" style="margin-top:20px">
                 <div class="card-content">
@@ -83,7 +83,7 @@
             </div>
         @endif
     @endcan
-    @can('viewAllApplications', \App\Models\User::class)
+    @can('viewAll', \App\Models\ApplicationForm::class)
         <div class="fixed-action-btn">
             <a href="{{ route('applications.export') }}" class="btn-floating btn-large">
                 <i class="large material-icons">file_download</i>

--- a/resources/views/auth/application/status.blade.php
+++ b/resources/views/auth/application/status.blade.php
@@ -1,4 +1,4 @@
-@can('viewSomeApplication', \App\Models\User::class)
+@can('viewSome', \App\Models\ApplicationForm::class)
     @switch($status)
         @case(App\Models\ApplicationForm::STATUS_IN_PROGRESS)
             Folyamatban
@@ -18,8 +18,7 @@
         @default
             <i>Ismeretlen</i>
     @endswitch
-@endcan
-@cannot('viewSomeApplication', \App\Models\User::class)
+@else
     @switch($status)
         @case(App\Models\ApplicationForm::STATUS_IN_PROGRESS)
             Folyamatban
@@ -27,4 +26,4 @@
         @default
             Véglegesítve
     @endswitch
-@endcannot
+@endcan


### PR DESCRIPTION
The problem was that old names of policies were used instead of the new ones in ApplicationFormPolicy. Therefore, applications did not appear correctly and unfinished applications were hidden.