### PR TITLE
Last-minute fixes to application process

### DIFF
--- a/app/Http/Controllers/Auth/AdmissionController.php
+++ b/app/Http/Controllers/Auth/AdmissionController.php
@@ -133,9 +133,13 @@ class AdmissionController extends Controller
      * @return RedirectResponse
      * @throws AuthorizationException
      */
-    public function update(Request $request, Application $application): RedirectResponse
+    public function updateNote(Request $request, Application $application): RedirectResponse
     {
         $this->authorize('view', $application);
+        if (user()->id == $application->user_id) {
+            return redirect()->back()->with('error', 'You cannot modify the internal note of yourself.');
+        }
+
         $newStatus = $request->input('status_'.$application->user->id);
         if ($request->has('note')) {
             $application->update(['note' => $request->input('note')]);
@@ -192,7 +196,8 @@ class AdmissionController extends Controller
         //        });
         //
         //        Cache::clear();
-        return back()->with('message', 'Sikeresen jóváhagyta az elfogadott jelentkezőket');
+        // return back()->with('message', 'Sikeresen jóváhagyta az elfogadott jelentkezőket');
+        return back()->with('error', 'Még nincs implementálva.');
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -127,8 +127,10 @@ class RegisterController extends Controller
                     Mail::to($admin)->send(new NewRegistration($admin->name, $user));
                 }
                 Cache::increment('user');
+                $this->redirectTo = '/verification';
             } else {
                 $user->application()->create();
+                $this->redirectTo = '/application';
             }
 
             return $user;

--- a/app/Http/Controllers/Secretariat/UserController.php
+++ b/app/Http/Controllers/Secretariat/UserController.php
@@ -180,6 +180,12 @@ class UserController extends Controller
             'research_topics',
             'extra_information'
         ]);
+
+        // whether Neptun code is unique
+        if (EducationalInformation::where('neptun', $request->neptun)->where('user_id', '<>', $user->id)->exists()) {
+            return redirect()->back()->with('error', 'A megadott Neptun-kód már létezik! Ha a kód az Öné, lépjen be a korábbi fiókjával.');
+        }
+
         DB::transaction(function () use ($user, $request, $educational_data) {
             if (!$user->hasEducationalInformation()) {
                 $user->educationalInformation()->create($educational_data);

--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -32,19 +32,16 @@ class ApplicationPolicy
      */
     public function view(User $user, Application $target): bool
     {
-        if ($user->id == $target->user_id) {
+        if ($user->id == $target->user_id || $user->can('viewAll', Application::class)) {
             return true;
-        }
-        if ($user->can('viewAll', Application::class)) {
-            return true;
-        }
-
-        return $target->appliedWorkshops
+        } else {
+            return $target->appliedWorkshops
                 ->intersect($user->applicationCommitteWorkshops)
                 ->count() > 0
             || $target->appliedWorkshops
                 ->intersect($user->roleWorkshops)
                 ->count() > 0;
+        }
     }
 
     /**

--- a/app/Utils/ApplicationHandler.php
+++ b/app/Utils/ApplicationHandler.php
@@ -20,8 +20,9 @@ trait ApplicationHandler
     {
         $data = $request->validate([
             'status' => 'required|in:extern,resident',
-            'graduation_average' => 'required|numeric',
-            'semester_average' => 'nullable',
+            'graduation_average' => 'required|numeric|min:1|max:5',
+            'semester_average' => 'nullable|array',
+            'semester_average.*' => 'numeric|min:1|max:5',
             'competition' => 'nullable',
             'publication' => 'nullable',
             'foreign_studies' => 'nullable',
@@ -74,7 +75,7 @@ trait ApplicationHandler
 
         $file = $user->application->files()->findOrFail($request->input('id'));
 
-        Storage::delete($file->path);
         $file->delete();
+        Storage::delete($file->path);
     }
 }

--- a/app/Utils/ApplicationHandler.php
+++ b/app/Utils/ApplicationHandler.php
@@ -20,9 +20,9 @@ trait ApplicationHandler
     {
         $data = $request->validate([
             'status' => 'required|in:extern,resident',
-            'graduation_average' => 'required|numeric|min:1|max:5',
+            'graduation_average' => 'required|numeric',
             'semester_average' => 'nullable|array',
-            'semester_average.*' => 'numeric|min:1|max:5',
+            'semester_average.*' => 'numeric',
             'competition' => 'nullable',
             'publication' => 'nullable',
             'foreign_studies' => 'nullable',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -66,6 +66,7 @@ return [
         'option' => 'vote',
         'alfonso_language' => 'Alfonsó language',
         'alfonso_desired_level' => 'Alfonsó level',
+        'semester_average' => array_fill(0, 10, 'average in earlier semester'), // from semester_average.0 to semester_average.9
         'question_1' => "\"Honnan hallott a Collegiumról?\" question",
         'question_1_other' => "\"Honnan hallott a Collegiumról?\" question's other value",
         'question_2' => "\"Miért kíván a Collegium tagja lenni?\" question",

--- a/resources/lang/hu/validation.php
+++ b/resources/lang/hu/validation.php
@@ -66,6 +66,7 @@ return [
         'option' => 'szavazat',
         'alfonso_language' => 'Alfonsó nyelv',
         'alfonso_desired_level' => 'Alfonsó szint',
+        'semester_average' => array_fill(0, 10, 'korábbi szemeszter átlaga'), // from semester_average.0 to semester_average.9
         'question_1' => "\"Honnan hallott a Collegiumról?\" kérdés",
         'question_1_other' => "\"Honnan hallott a Collegiumról?\" kérdés egyéb mezője",
         'question_2' => "\"Miért kíván a Collegium tagja lenni?\" kérdés",

--- a/resources/views/auth/admission/application.blade.php
+++ b/resources/views/auth/admission/application.blade.php
@@ -8,7 +8,7 @@
 @section('content')
     @include('auth.application.application', ['user' => $user, 'expanded' => true, 'admin' => $admin ?? false])
     <div class="card">
-        <form method="POST" action="{{route('admission.applicants.edit', ['application' => $user->application->id])}}">
+        <form method="POST" action="{{route('admission.applicants.update_note', ['application' => $user->application->id])}}">
             <div class="card-content">
                 <div class="row">
                     @csrf

--- a/resources/views/auth/application/app.blade.php
+++ b/resources/views/auth/application/app.blade.php
@@ -31,16 +31,21 @@
             <blockquote>
                 @if(!$user->application->submitted)
                     <p>A jelentkezése jelen állapotában még nem látható a felvételiztető bizottság számára! </p>
-                    <p>A jelentkezése bármikor félbe szakítható, a regisztrációnál megadott e-mail címmel és jelszóval
-                        belépve bármikor visszatérhet erre az oldalra, és folytathatja az űrlap kitöltését.</p>
-                    <p>Minden mező kötelező, ahol az ellenkezője nincs külön jelezve. Miután minden szükséges kérdést megválaszolt és fájlt feltöltött,
-                        kérjük, véglegesítse a jelentkezését a lap alján lévő gombra kattintva.</p>
-                    <p>Kérjük figyeljen a határidőre, mert utána már nem lesz lehetősége véglegesíteni azt.</p>
+
+                    <ul class="browser-default">
+                        <li>Jelentkezése bármikor félbeszakítható: a regisztrációnál megadott e-mail címmel és jelszóval
+                            belépve bármikor visszatérhet erre az oldalra, és folytathatja az űrlap kitöltését.</li>
+                        <li>Minden mező kötelező, ahol az ellenkezője nincs külön jelezve.</li>
+                        <li>Miután minden szükséges kérdést megválaszolt és fájlt feltöltött,
+                            véglegesítse jelentkezését a lap alján lévő gombra kattintva.
+                            Kérjük, figyeljen a határidőre, mert utána már nem lesz lehetősége véglegesítésre.</li>
+                    </ul>
+
                     <p>Amennyiben bármi kérdése lenne a felvételivel kapcsolatban, kérjük, írjon a
-                        <a href="mailto:{{config('mail.secretary_mail')}}">{{config('mail.secretary_mail')}}</a> e-mail címre. Ha
-                        technikai
-                        probléma adódna, kérjük, jelezze felénk a <a href="mailto:{{config('mail.sys_admin_mail')}}">{{config('mail.sys_admin_mail')}}</a>
-                        e-mail címen.
+                        <a href="mailto:{{config('mail.secretary_mail')}}">{{config('mail.secretary_mail')}}</a> e-mail címre.
+                        Ha technikai probléma adódna,
+                        jelezze felénk a <a href="mailto:{{config('mail.sys_admin_mail')}}">{{config('mail.sys_admin_mail')}}</a>
+                        e-mail-címen.
                     </p>
                 @else
                     <p>Köszönjük, hogy jelentkezett az Eötvös Collegiumba!</p>

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -7,10 +7,10 @@
             @csrf
             <div class="card-content">
                 <div class="row">
-                    <x-input.text s=12 id="graduation_average" text="application.graduation_average" type='number' step="0.01" min="1"
-                                  max="5" text="Érettségi átlaga" :value="$user->application->graduation_average"
+                    <x-input.text s=12 id="graduation_average" text="application.graduation_average" type='number' step="0.01" min="0"
+                                  text="Érettségi átlaga" :value="$user->application->graduation_average"
                                   required
-                                  helper='Az összes érettségi tárgy hagyományos átlaga (tizedesponttal)'/>
+                                  helper='Az összes érettségi tárgy hagyományos átlaga'/>
                     <div class="col s12">
                         @livewire('parent-child-form', [
                         'title' => "Van lezárt egyetemi félévem",

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -7,15 +7,15 @@
             @csrf
             <div class="card-content">
                 <div class="row">
-                    <x-input.text s=12 id="graduation_average" text="application.graduation_average" type='number' step="0.01" min="0"
+                    <x-input.text s=12 id="graduation_average" text="application.graduation_average" type='number' step="0.01" min="1"
                                   max="5" text="Érettségi átlaga" :value="$user->application->graduation_average"
                                   required
-                                  helper='Az összes érettségi tárgy hagyományos átlaga'/>
+                                  helper='Az összes érettségi tárgy hagyományos átlaga (tizedesponttal)'/>
                     <div class="col s12">
                         @livewire('parent-child-form', [
                         'title' => "Van lezárt egyetemi félévem",
                         'name' => 'semester_average',
-                        'helper' => 'Hagyományos átlag a félév(ek)ben',
+                        'helper' => 'Hagyományos átlag a félév(ek)ben (tizedesponttal)',
                         'optional' => true,
                         'items' => $user->application->semester_average])
                     </div>

--- a/resources/views/utils/user/profile-picture.blade.php
+++ b/resources/views/utils/user/profile-picture.blade.php
@@ -2,7 +2,7 @@
 <div class="card horizontal hide-on-med-and-down">
     <div class="card-image">
         <img src="{{ url($user->profilePicture ? $user->profilePicture->path : '/img/avatar.png') }}"
-                style="max-width:300px">
+                style="max-width:300px; max-height:500px;">
     </div>
     <div class="card-stacked">
         <div class="card-content">

--- a/routes/web.php
+++ b/routes/web.php
@@ -176,7 +176,7 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
 
     Route::get('/applicants', [AdmissionController::class, 'index'])->name('admission.applicants.index');
     Route::get('/applicants/{application}', [AdmissionController::class, 'show'])->name('admission.applicants.show');
-    Route::post('/applicants/{application}', [AdmissionController::class, 'update'])->name('admission.applicants.update');
+    Route::post('/applicants/{application}', [AdmissionController::class, 'updateNote'])->name('admission.applicants.update_note');
 
     /** Faults */
     Route::get('/faults', [FaultController::class, 'index'])->name('faults');

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -106,7 +106,7 @@ class ApplicationTest extends TestCase
             'page' => 'questions',
             "graduation_average" => "3",
             "semester_average" => [
-                "3.3", "3.5", "5"
+                "3.3", "3.5", "3231"
             ],
             "status" => "resident",
             "question_1" => [
@@ -126,7 +126,7 @@ class ApplicationTest extends TestCase
 
         $this->assertTrue($user->application->applied_for_resident_status);
         $this->assertEquals('3', $user->application->graduation_average);
-        $this->assertEquals(["3.3", "3.5", "5"], $user->application->semester_average);
+        $this->assertEquals(["3.3", "3.5", "3231"], $user->application->semester_average);
         $this->assertEquals(["question 1_1", "question 1_2"], $user->application->question_1);
         $this->assertEquals("question 2", $user->application->question_2);
         $this->assertEquals("question 3", $user->application->question_3);

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -106,7 +106,7 @@ class ApplicationTest extends TestCase
             'page' => 'questions',
             "graduation_average" => "3",
             "semester_average" => [
-                "3.3", "3.5", "3231"
+                "3.3", "3.5", "5"
             ],
             "status" => "resident",
             "question_1" => [
@@ -126,7 +126,7 @@ class ApplicationTest extends TestCase
 
         $this->assertTrue($user->application->applied_for_resident_status);
         $this->assertEquals('3', $user->application->graduation_average);
-        $this->assertEquals(["3.3", "3.5", "3231"], $user->application->semester_average);
+        $this->assertEquals(["3.3", "3.5", "5"], $user->application->semester_average);
         $this->assertEquals(["question 1_1", "question 1_2"], $user->application->question_1);
         $this->assertEquals("question 2", $user->application->question_2);
         $this->assertEquals("question 3", $user->application->question_3);


### PR DESCRIPTION
Replaying still actual fixes of #572 onto new code, as well as of some newly spotted bugs.

- Newly registered applicants were redirected to the tenant verification page after registration. This is now fixed.
- There had been an error while creating WiFi access if the Neptun code was not unique.
- Changed strange order of operations in `deleteFile()` in AdmissionController.
- Renamed `update` route to `update_note` (that is more descriptive).
- An applicant now cannot modify the internal note of themselves, even through a well-formed POST request.
- Handling abnormally tall and slim profile pictures.
- Refactoring information box on top of application page.
- Requiring a number ~~between 1 and 5~~ for averages.

Those with "view" permission can still theoretically modify applicant data through a POST request. But we can [leave this for now](https://github.com/EotvosCollegium/mars/pull/572/files#r1685508000).