### PR TITLE
Inverting the preloader (the splash animation) for dark theme

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -57,6 +57,9 @@
         z-index: 9999;
         background: url(/loading.gif) center no-repeat #fff;
     }
+    .dark .preloader {
+        filter: invert(100%);
+    }
     </style>
 
 </head>


### PR DESCRIPTION
As in the title. The white flash every time I reloaded really bugged me :sweat_smile: