### PR TITLE
Use the main navbar layout on the welcome page

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -68,7 +68,7 @@
 <body>
     <script>document.body.classList.add(localStorage.getItem('themeMode') || 'light');</script>
     <header>
-        @include('layouts.navbar')
+        @include('layouts.navbar', ['fixed' => true])
     </header>
     <div class="row">
         <div class="container">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -26,7 +26,7 @@
 </div>
 
 <!--sidebar-->
-<ul class="sidenav sidenav-fixed" id="sidenav">
+<ul class="sidenav @if ($fixed) sidenav-fixed @endif" id="sidenav">
     <!-- logo -->
     @include('layouts.logo')
     @if(config('app.env') == 'production' && config('app.debug'))

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -13,34 +13,16 @@
     <link rel="stylesheet" href="{{ mix('css/welcome_page.css') }}">
     <link type="text/css" rel="stylesheet" href="{{ mix('css/materialize.css') }}" media="screen,projection" />
 
-    @if (config('app.debug'))
-        <!-- Scripts -->
-        <script type="text/javascript" src="{{ mix('js/jquery.min.js') }}"></script>
-        <script type="text/javascript" src="{{ mix('js/materialize.js') }}"></script>
-    @endif
+    <!-- Scripts -->
+    <script type="text/javascript" src="{{ mix('js/jquery.min.js') }}"></script>
+    <script type="text/javascript" src="{{ mix('js/materialize.js') }}"></script>
 </head>
 
 <body>
     <script>document.body.classList.add(localStorage.getItem('themeMode') || 'light');</script>
     @if (Route::has('login'))
     <header>
-        <div class="navbar-fixed">
-            <nav class="top-nav">
-                <div class="nav-wrapper">
-                    <div class="row">
-                        <ul class="right">
-                            @auth
-                            <li><a href="{{ url('/home') }}">@lang('general.home')</a></li>
-                            @else
-                            <li><a href="{{ route('login') }}">@lang('general.login')</a></li>
-                            <li><a href="{{ route('register') }}">@lang('general.register_collegist')</a></li>
-                            <li><a href="{{ route('register.guest') }}">@lang('general.register_guest')</a></li>
-                            @endauth
-                        </ul>
-                    </div>
-                </div>
-            </nav>
-        </div>
+        @include('layouts.navbar', ['fixed' => false])
     </header>
     @endif
     </header>
@@ -78,13 +60,13 @@
             @lang('main.open')</a><br class="mobile-break" />
     </div>
 
-    @if (config('app.debug'))
-        <script>
-            $(document).ready(function(){
-                $('.tooltipped').tooltip();
-            });
-        </script>
-    @endif
+    <script>
+        $(document).ready(function(){
+            $('.tooltipped').tooltip();
+            $('.sidenav').sidenav();
+            $('.collapsible').collapsible();
+        });
+    </script>
 </body>
 
 </html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -26,10 +26,6 @@
     <header>
         <div class="navbar-fixed">
             <nav class="top-nav">
-                <ul id="register-dropdown" class="dropdown-content">
-                    <li><a href="{{ route('register') }}">@lang('general.register_collegist')</a></li>
-                    <li><a href="{{ route('register.guest') }}">@lang('general.register_guest')</a></li>
-                </ul>
                 <div class="nav-wrapper">
                     <div class="row">
                         <ul class="right">
@@ -37,7 +33,8 @@
                             <li><a href="{{ url('/home') }}">@lang('general.home')</a></li>
                             @else
                             <li><a href="{{ route('login') }}">@lang('general.login')</a></li>
-                            <li><a class="dropdown-trigger" href="#!" data-target="register-dropdown">@lang('general.register')<i class="material-icons right">arrow_drop_down</i></a></li>
+                            <li><a href="{{ route('register') }}">@lang('general.register_collegist')</a></li>
+                            <li><a href="{{ route('register.guest') }}">@lang('general.register_guest')</a></li>
                             @endauth
                         </ul>
                     </div>
@@ -81,12 +78,13 @@
             @lang('main.open')</a><br class="mobile-break" />
     </div>
 
-    <script>
-        $(document).ready(function(){
-            $('.tooltipped').tooltip();
-            $(".dropdown-trigger").dropdown();
-        });
-    </script>
+    @if (config('app.debug'))
+        <script>
+            $(document).ready(function(){
+                $('.tooltipped').tooltip();
+            });
+        </script>
+    @endif
 </body>
 
 </html>


### PR DESCRIPTION
This automatically turns the top nav links ("Login", "Application for
college students" and "Register for tenants") automatically turn into a
sidenav on mobile.

The easiest way I could make the logo stay centered on desktop is to
make the side nav only show on mobile layouts. I made the navbar blade
take a parameter indicating if we want it fixed (like on the main UI).

The layout of other pages are unaffected.

This partially reverts #576 

Desktop layout:
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/c6a5bdc7-19c5-4499-b9a6-6f7d8c0b2b5d">

Mobile layout:
<img width="390" alt="image" src="https://github.com/user-attachments/assets/b6978f8b-c6d9-410c-9a0d-bc1711737627">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/c7786553-b10a-4551-91f9-efe3accd6604">
