### PR TITLE
Always prefer Hungarian if the user speaks it

### DIFF
--- a/app/Http/Middleware/Locale.php
+++ b/app/Http/Middleware/Locale.php
@@ -16,8 +16,13 @@ class Locale
      */
     public function handle($request, Closure $next)
     {
-        $locales = array_keys(config('app.locales'));
-        App::setLocale($request->cookie('locale', $request->getPreferredLanguage($locales)));
+        $appLocales = array_keys(config('app.locales'));
+        $acceptedByUser = $request->getLanguages();
+        $default = config('app.locale');
+
+        /* If the user speaks the site's main language, we should always select that, even if others have a higher priority. */
+        $selected = in_array($default, $acceptedByUser) ? $default : $request->getPreferredLanguage($appLocales);
+        App::setLocale($request->cookie('locale', $selected));
         return $next($request);
     }
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -15,7 +15,12 @@
             </div>
             <div class="card-content">
                 @if($user_type == \App\Models\Role::COLLEGIST)
-                <blockquote><a href="{{route('register.guest')}}" style="text-decoration: underline">@lang('registration.information_tenant')</a></blockquote>
+                <blockquote>
+                    <a href="{{route('register.guest')}}" style="text-decoration: underline">@lang('registration.information_tenant')</a>
+                </blockquote>
+                <blockquote lang="en">
+                    <a href="{{route('register.guest')}}" style="text-decoration: underline">@lang('registration.information_tenant', [], 'en')</a>
+                </blockquote>
                 @endif
                 @if($user_type == \App\Models\Role::TENANT || $application_open ?? false)
                 <form method="POST" action="{{ route('register') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,9 +68,15 @@ Route::get('/privacy_policy', [HomeController::class, 'privacyPolicy'])->name('p
 Route::get('/img/{filename}', [HomeController::class, 'getPicture']);
 Route::get('/setlocale/{locale}', [HomeController::class, 'setLocale'])->name('setlocale');
 
-Auth::routes(); //check \Laravel\Ui\AuthRouteMethods
+Auth::routes(['register' => false]); //check \Laravel\Ui\AuthRouteMethods
 
-Route::get('/register/guest', [RegisterController::class, 'showTenantRegistrationForm'])->name('register.guest');
+/* Override the /register route from Auth::routes to force Hungarian */
+Route::prefix('/register')->group(function () {
+    Route::post('/', [RegisterController::class, 'register']);
+
+    Route::get('/', [RegisterController::class, 'showRegistrationForm'])->name('register')->middleware(OnlyHungarian::class);
+    Route::get('/guest', [RegisterController::class, 'showTenantRegistrationForm'])->name('register.guest');
+});
 
 Route::middleware([Authenticate::class, LogRequests::class])->group(function () {
     /** Routes that needs to be accessed during the application process */


### PR DESCRIPTION
Even if the user has English as the highest priority entry in their Accept-Language header, we should select Hungarian by default if it's one of the languages that the user speaks.
