### PR TITLE
Fix special chars in `x-input.text` being doubly escaped

### DIFF
--- a/app/View/Components/Input/Text.php
+++ b/app/View/Components/Input/Text.php
@@ -13,13 +13,15 @@ class Text extends Input
      * Create a new text input instance.
      *
      * @param  string  $helper  helper message
+     * @param  ?string $value   pre-filled contents
      * @return void
      */
-    public function __construct($id, $withoutLabel = false, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $helper = null)
+    public function __construct($id, $withoutLabel = false, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $helper = null, ?string $value = '')
     {
         parent::__construct($id, $text, $s, $m, $l, $xl, $onlyInput);
         $this->helper = $helper;
         $this->withoutLabel = $withoutLabel;
+        $this->value = $value;
     }
 
     /**

--- a/app/View/Components/Input/Textarea.php
+++ b/app/View/Components/Input/Textarea.php
@@ -12,12 +12,14 @@ class Textarea extends Input
      * Create a new textarea input instance.
      *
      * @param  string  $helper  helper message
+     * @param  ?string $value   pre-filled contents
      * @return void
      */
-    public function __construct($id, $helper = null, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false)
+    public function __construct($id, $helper = null, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, ?string $value = '')
     {
         parent::__construct($id, $text, $s, $m, $l, $xl, $onlyInput);
         $this->helper = $helper;
+        $this->value = $value;
     }
 
     /**

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -4,7 +4,7 @@
     <input
         id="{{$id}}"
         class="validate @error($id) invalid @enderror"
-        value="{{old($id) ?? $attributes->get('value')}}"
+        value="{{old($id, $value ?? '')}}"
         {{-- Default values + other provided attributes --}}
         {{$attributes->whereDoesntStartWith('value')->merge([
             'type' => 'text',

--- a/resources/views/components/input/textarea.blade.php
+++ b/resources/views/components/input/textarea.blade.php
@@ -6,7 +6,7 @@
         {{$attributes->whereDoesntStartWith('value')->merge([
             'name' => $id,
             'class' => "materialize-textarea validate"
-        ])}}>{{old($id) ?? $attributes->get('value')}}</textarea>
+        ])}}>{{old($id, $value ?? '')}}</textarea>
     <label for="{{$id}}">{{$label}}</label>
     @if($helper ?? null)
     <span class="helper-text">{{ $helper }}</span>

--- a/resources/views/dormitory/print/print.blade.php
+++ b/resources/views/dormitory/print/print.blade.php
@@ -17,7 +17,7 @@
             @method('PUT')
             <div class="row">
                 <x-input.file l=8 xl=10 id="file_to_upload" accept=".pdf" required text="print.select_document"/>
-                <x-input.text l=4 xl=2  id="number_of_copies" type="number" min="1" value="1" required text="print.number_of_copies"/>
+                <x-input.text l=4 xl=2  id="number_of_copies" type="number" min="1" :value="1" required text="print.number_of_copies"/>
                 <x-input.checkbox s=8 xl=4 name="two_sided" checked text="print.twosided"/>
                 @if($free_pages>0) {{-- only show when user have active free pages --}}
                     <x-input.checkbox s=8 xl=4 name="use_free_pages" text="print.use_free_pages"/>

--- a/resources/views/network/internet/report_fault.blade.php
+++ b/resources/views/network/internet/report_fault.blade.php
@@ -19,7 +19,7 @@
                     <x-input.text id="tries" text="internet.report_fault_tries"/>
                     <x-input.text id="user_os" required text="internet.report_fault_os"
                                   placeholder="pl. Windows 11 / Android 12 / MacOS / Ubuntu"/>
-                    <x-input.text id="room" text="general.room" value="{{user()->room}}"/>
+                    <x-input.text id="room" text="general.room" :value="user()->room"/>
                     <x-input.text l=6 id="availability" text="internet.report_fault_availability"/>
                     <x-input.checkbox l=6 id="can_enter" checked text="internet.report_fault_can_enter_room"/>
                     <x-input.button class="right" text="general.send"/>

--- a/resources/views/network/routers/edit.blade.php
+++ b/resources/views/network/routers/edit.blade.php
@@ -17,26 +17,26 @@
                 <div class="card-content">
                     <span class="card-title">@lang('router.edit')</span>
                     <div class="row">
-                        <x-input.text s="6" type="text" text="router.ip" id="ip" value="{{ $router->ip }}" maxlength="15" required/>
-                        <x-input.text s="6" type="text" text="router.room" id="room" value="{{ $router->room }}" maxlength="5" required/>
+                        <x-input.text s="6" type="text" text="router.ip" id="ip" :value="$router->ip" maxlength="15" required/>
+                        <x-input.text s="6" type="text" text="router.room" id="room" :value="$router->room" maxlength="5" required/>
                     </div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="router.port" id="port" value="{{ $router->port }}"/>
-                        <x-input.text s="4" type="text" text="router.type" id="type" value="{{ $router->type }}"/>
-                        <x-input.text s="4" type="text" text="router.serial_number" id="serial_number" value="{{ $router->serial_number }}"/>
+                        <x-input.text s="4" type="text" text="router.port" id="port" :value="$router->port"/>
+                        <x-input.text s="4" type="text" text="router.type" id="type" :value="$router->type"/>
+                        <x-input.text s="4" type="text" text="router.serial_number" id="serial_number" :value="$router->serial_number"/>
                     </div>
                     <div><p>@lang('internet.mac_address')</p></div>
                     <div class="row">
-                        <x-input.text s="4" type="text" text="WAN" id="mac_WAN" value="{{ $router->mac_WAN }}"/>
-                        <x-input.text s="4" type="text" text="2G/LAN" id="mac_2G_LAN" value="{{ $router->mac_2G_LAN }}"/>
-                        <x-input.text s="4" type="text" text="5G" id="mac_5G" value="{{ $router->mac_5G }}"/>
+                        <x-input.text s="4" type="text" text="WAN" id="mac_WAN" :value="$router->mac_WAN"/>
+                        <x-input.text s="4" type="text" text="2G/LAN" id="mac_2G_LAN" :value="$router->mac_2G_LAN"/>
+                        <x-input.text s="4" type="text" text="5G" id="mac_5G" :value="$router->mac_5G"/>
                     </div>
                     <div class="row">
-                        <x-input.text type="text" id="comment" text="general.comment" value="{{ $router->comment }}" maxlength="255"/>
+                        <x-input.text type="text" id="comment" text="general.comment" :value="$router->comment" maxlength="255"/>
                     </div>
                     <div class="row">
-                        <x-input.text s="6" type="date" id="date_of_acquisition" text="router.date_of_acquisition" value="{{ $router->date_of_acquisition }}"/>
-                        <x-input.text s="6" type="date" id="date_of_deployment" text="router.date_of_deployment" value="{{ $router->date_of_deployment }}"/>
+                        <x-input.text s="6" type="date" id="date_of_acquisition" text="router.date_of_acquisition" :value="$router->date_of_acquisition"/>
+                        <x-input.text s="6" type="date" id="date_of_deployment" text="router.date_of_deployment" :value="$router->date_of_deployment"/>
                     </div>
                 </div>
                 <div class="card-action">

--- a/resources/views/secretariat/evaluation-form/course.blade.php
+++ b/resources/views/secretariat/evaluation-form/course.blade.php
@@ -2,12 +2,12 @@
     <x-input.text id="courses[{{$index}}][name]"
                     l=5
                     text="Kurzus neve"
-                    value="{{ $value ? $value['name'] ?? '' : '' }}"
+                    :value="($value ? $value['name'] ?? '' : '')"
                     required />
     <x-input.text id="courses[{{$index}}][code]{{ $index }}"
                     l=3
                     text="Kurzus kódja"
-                    value="{{ $value ? $value['code'] ?? '' : '' }}"
+                    :value="($value ? $value['code'] ?? '' : '')"
                     required />
     <x-input.text id="courses[{{$index}}][grade]"
                     l=3 s=11
@@ -15,7 +15,7 @@
                     min="1"
                     max="5"
                     text="Jegy"
-                    value="{{ $value ? $value['grade'] ?? '' : '' }}"
+                    :value="($value ? $value['grade'] ?? '' : '')"
                     helper="(ha ismert)" />
     <x-input.button type="button" s="1" class="right red" floating icon="delete" onclick="removeCourse({{$index}})"/>
 </div>

--- a/resources/views/utils/question_card.blade.php
+++ b/resources/views/utils/question_card.blade.php
@@ -15,7 +15,7 @@
         @livewire('parent-child-form', ['title' => __('voting.options'), 'name' => 'options', 'items' => old('options')])
     </div>
     <div class="row">
-        <x-input.text type="number" value="1" id="max_options" text="voting.max_options" required/>
+        <x-input.text type="number" :value="1" id="max_options" text="voting.max_options" required/>
     </div>
     @if ($canHaveLongAnswers)
     <div class="row">


### PR DESCRIPTION
Per the [Laravel docs](https://laravel.com/docs/11.x/blade#passing-data-to-components):

> PHP expressions and variables should be passed to the component via attributes that use the : character as a prefix

Otherwise, HTML special characters get entity-escaped both when being passed to `x-input.text` and inside that component to the HTML `text` element. Without this, entering `a < b` would render as `a &lt; b`, then after an edit: `a &amp;lt; b`, etc...

Obsoletes #456

