### PR TITLE
Add hint for applicants with existing accounts to log in

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -21,6 +21,9 @@
                 <blockquote lang="en">
                     <a href="{{route('register.guest')}}" style="text-decoration: underline">@lang('registration.information_tenant', [], 'en')</a>
                 </blockquote>
+                <blockquote>
+                    Ha már rendelkezel {{ config('app.name') }} fiókkal, <a href="{{ route('login') }}">belépést</a> követően adhatod le jelentkezésed.
+                </blockquote>
                 @endif
                 @if($user_type == \App\Models\Role::TENANT || $application_open ?? false)
                 <form method="POST" action="{{ route('register') }}">


### PR DESCRIPTION
This is shown unconditionally on the applicant registration page, which is easier than trying to specifically handle duplicate email address errors. I don't like that we're showing 4 (!) such messages on this page, we might want to come up with a nicer solution in the future.

<img width="523" alt="image" src="https://github.com/user-attachments/assets/e9b56d9c-1643-4121-a116-d77168e39d93">

