### PR TITLE
Displaying the status update panel for those with no role whatsoever

### DIFF
--- a/app/Http/Middleware/RedirectToStatusUpdate.php
+++ b/app/Http/Middleware/RedirectToStatusUpdate.php
@@ -38,6 +38,10 @@ class RedirectToStatusUpdate
         if ($user->application) {
             return $next($request);
         }
+        // Ignore those having any role
+        if ($user->roles()->exists()) {
+            return $next($request);
+        }
         return redirect(route('users.tenant-update.show'));
     }
 }

--- a/app/Http/Middleware/RedirectToStatusUpdate.php
+++ b/app/Http/Middleware/RedirectToStatusUpdate.php
@@ -5,11 +5,11 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 
-class RedirectTenantsToUpdate
+class RedirectToStatusUpdate
 {
     /**
      * Redirects tenants to update their tenant_until property if it is in the past.
-     * This way we can distinguish between the active and inactive tenants.
+     * Also appears to users with no status whatsoever (neither collegist nor tenant).
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse) $next
@@ -32,6 +32,10 @@ class RedirectTenantsToUpdate
         }
         // Ignore if update is not necessary
         if (!$user->needsUpdateTenantUntil()) {
+            return $next($request);
+        }
+        // Ignore those having an application in progress
+        if ($user->application) {
             return $next($request);
         }
         return redirect(route('users.tenant-update.show'));

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -282,6 +282,14 @@ class Role extends Model
     }
 
     /**
+     * Returns the role for tenants.
+     */
+    public static function tenant(): Role
+    {
+        return self::where('name', self::TENANT)->first();
+    }
+
+    /**
      * Get the translated_name attribute.
      *
      * @return Attribute

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -834,11 +834,12 @@ class User extends Authenticatable implements HasLocalePreference
 
     /**
      * @return bool if the user needs to update their tenant status
-     * A user needs to update their tenant status if they are a tenant and their tenant_until date is in the past.
+     * A user needs to update their tenant status if they are a tenant and their tenant_until date is in the past;
+     * or if they have no status whatsoever.
      */
     public function needsUpdateTenantUntil(): bool
     {
-        return $this->isTenant() && !$this->isCurrentTenant();
+        return !$this->isCollegist() && !$this->isCurrentTenant();
     }
 
     /* Status related */

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,7 +3,7 @@
 use App\Http\Middleware\Locale;
 use App\Http\Middleware\LogRequests;
 use App\Http\Middleware\NotifyAboutEvaluation;
-use App\Http\Middleware\RedirectTenantsToUpdate;
+use App\Http\Middleware\RedirectToStatusUpdate;
 use App\Jobs\PeriodicEventsProcessor;
 use App\Jobs\PingRouters;
 use App\Jobs\ProcessWifiConnections;
@@ -37,7 +37,7 @@ return Application::configure(basePath: dirname(__DIR__))
             Locale::class,
             LogRequests::class,
             NotifyAboutEvaluation::class,
-            RedirectTenantsToUpdate::class
+            RedirectToStatusUpdate::class
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/resources/views/auth/application/app.blade.php
+++ b/resources/views/auth/application/app.blade.php
@@ -25,7 +25,7 @@
                 @endif
             </h6>
             @if (!$user->application->submitted)
-                Hátra van: <i>{{ (int) \Carbon\Carbon::now()->diffInDays($deadline, false) }}</i> nap.
+                Hátralevő idő: <i>{{ (int) \Carbon\Carbon::now()->diffInDays($deadline, false) }}</i> nap.
             @endif
 
             <blockquote>

--- a/routes/web.php
+++ b/routes/web.php
@@ -76,6 +76,8 @@ Route::prefix('/register')->group(function () {
 
     Route::get('/', [RegisterController::class, 'showRegistrationForm'])->name('register')->middleware(OnlyHungarian::class);
     Route::get('/guest', [RegisterController::class, 'showTenantRegistrationForm'])->name('register.guest');
+
+    Route::post('/rerequest_tenant_status', [RegisterController::class, 'rerequestTenantStatus'])->name('register.rerequest_tenant_status');
 });
 
 Route::middleware([Authenticate::class, LogRequests::class])->group(function () {

--- a/tests/Feature/AdminInternetControllerTest.php
+++ b/tests/Feature/AdminInternetControllerTest.php
@@ -23,6 +23,8 @@ class AdminInternetControllerTest extends TestCase
     {
         $response = $this->actingAs($this->user)->get(route('internet.admin.index'));
 
+        echo substr(json_encode($response),0,500);
+
         $response->assertStatus(403);
     }
 

--- a/tests/Feature/AdminInternetControllerTest.php
+++ b/tests/Feature/AdminInternetControllerTest.php
@@ -23,7 +23,7 @@ class AdminInternetControllerTest extends TestCase
     {
         $response = $this->actingAs($this->user)->get(route('internet.admin.index'));
 
-        echo substr(json_encode($response),0,500);
+        echo substr(json_encode($response), 0, 500);
 
         $response->assertStatus(403);
     }

--- a/tests/Feature/PrintControllerTest.php
+++ b/tests/Feature/PrintControllerTest.php
@@ -16,6 +16,7 @@ class PrintControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $user->setVerified();
+        $user->addRole(Role::tenant()); // they need a role so that they do not get redirected
         $this->actingAs($user);
 
         // The user is not allowed to see the page without the correct permissions.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ abstract class TestCase extends BaseTestCase
         Mail::fake();
 
         $this->user = User::factory()->create(['verified' => true]);
+        $this->user->roles()->attach(Role::tenant()); // they need a role so that they don't get redirected
         $this->admin = User::factory()->create(['verified' => true]);
         $this->admin->roles()->attach(Role::sysAdmin());
 


### PR DESCRIPTION
Closes #603.

Displays the `tenant-update` panel (including the application link) for those having no roles at all (not even a tenant role), as is with the case for many prospective applicants.