### PR TITLE
Make university e-mails optional for applicants

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -292,10 +292,6 @@ class Application extends Model
             $missingData[] =  'Neptun-kód';
         }
 
-        if (is_null($educationalInformation?->email)) {
-            $missingData[] =  'Egyetemi e-mail-cím';
-        }
-
         // @phpstan-ignore-next-line
         if ($educationalInformation?->studyLines->count() == 0) {
             $missingData[] =  'Megjelölt szak';

--- a/resources/views/user/educational-information.blade.php
+++ b/resources/views/user/educational-information.blade.php
@@ -1,7 +1,10 @@
 <form method="POST" action="{{ route('users.update.educational', ['user' => $user]) }}">
     @csrf
     @if($application ?? false)
-        <blockquote>A Neptun-kódot és az egyetemi e-mail-címet elég véglegesítés előtt kitölteni.</blockquote>
+        <blockquote>
+            <p>A Neptun-kódot elég véglegesítés előtt kitölteni.</p>
+            <p>Az egyetemi e-mail-cím a felvételi eljárást követően is pótolható.</p>
+        </blockquote>
     @endif
     <div class="row">
         <x-input.text id="high_school" text="user.high_school"
@@ -30,7 +33,7 @@
                           :value="$user->educationalInformation?->neptun" /> {{-- not required --}}
             <x-input.text s=6 id='educational-email' text="user.educational-email" name="email"
                           :value="$user->educationalInformation?->email"
-                          helper="lehetőleg @student.elte.hu-s"/> {{-- not required --}}
+                          helper="lehetőleg @student.elte.hu-s (nem kötelező, a felvételit követően pótolható)"/> {{-- not required --}}
         @endif
 
         <div class="input-field col s12 m6">


### PR DESCRIPTION
They are expected to be set up for first-year students even later than Neptun codes (Wednesday being the earliest date), so we cannot have it be mandatory.
