### PR TITLE
docker-dev-setup: Install node from nodesource.com

### DIFF
--- a/docker-dev-setup/Dockerfile
+++ b/docker-dev-setup/Dockerfile
@@ -5,17 +5,16 @@ WORKDIR /workspace
 # Install PHP and other dependencies
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y wget tar xz-utils iputils-ping composer poppler-utils cups-client cm-super \
+    && apt-get install -y curl tar xz-utils iputils-ping composer poppler-utils cups-client cm-super \
                           libzip-dev libpng-dev libonig-dev libcurl4-openssl-dev libxml2-dev \
                           php8.2-cli php8.2-mysql php8.2-zip php8.2-gd php8.2-mbstring php8.2-curl php8.2-xml php8.2-bcmath \
                           texlive-latex-base texlive-latex-extra texlive-lang-european \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js
-RUN wget -nv -O node.tar.xz https://nodejs.org/dist/v20.9.0/node-v20.9.0-linux-x64.tar.xz && \
-    tar -xf node.tar.xz && \
-    rm node.tar.xz
-ENV PATH=$PATH:/workspace/node-v20.9.0-linux-x64/bin
+RUN curl -sL 'https://deb.nodesource.com/setup_20.x' | bash - \
+    && apt-get -y install nodejs \
+    && ln -s /usr/bin/nodejs /usr/local/bin/node
 
 WORKDIR /workspace/mars
 


### PR DESCRIPTION
This allows us to use native AArch64 builds on Apple Silicon Macs, so we no longer depend on Rosetta emulation working correctly (for some reason, it started to fail locally).
