### PR TITLE
Ensure that input IDs are unique on the checkout page

### DIFF
--- a/resources/views/utils/checkout/add-expense.blade.php
+++ b/resources/views/utils/checkout/add-expense.blade.php
@@ -27,13 +27,13 @@
         <form method="POST" action="{{ route($route_base . '.expense.add') }}" enctype="multipart/form-data">
             @csrf
             <div class="row">
-                <x-input.text m=6 l=6 id="comment" required text="Megjegyzés" />
-                <x-input.text type="number" m=6 l=6 id="amount" min=0 required text="Összeg" />
+                <x-input.text m=6 l=6 id="expense-comment" name="comment" required text="Megjegyzés" />
+                <x-input.text type="number" m=6 l=6 id="expense-amount" name="amount" min=0 required text="Összeg" />
                 @can('administrate', $checkout)
-                <x-input.select m=6 l=6 id="payer" text="Fizető" :elements="\App\Models\User::collegists()" default="{{user()->id}}" :formatter="function($user) { return $user->uniqueName; }" />
-                <x-input.checkbox m=6 l=6 id="paid" checked text="A tartozás kifizetésre került"/>
+                <x-input.select m=6 l=6 id="expense-payer" name="payer" text="Fizető" :elements="\App\Models\User::collegists()" default="{{user()->id}}" :formatter="function($user) { return $user->uniqueName; }" />
+                <x-input.checkbox m=6 l=6 id="expense-paid" name="paid" checked text="A tartozás kifizetésre került"/>
                 @endcan
-                <x-input.file s="12" id="receipt" style="margin-top:auto" accept=".pdf,.jpg,.png,.jpeg,.gif"
+                <x-input.file s="12" id="expense-receipt" name="receipt" style="margin-top:auto" accept=".pdf,.jpg,.png,.jpeg,.gif"
                                   text="checkout.receipt" required/>
             </div>
             <x-input.button floating class="btn-large right" icon="payments" />

--- a/resources/views/utils/checkout/add-income.blade.php
+++ b/resources/views/utils/checkout/add-income.blade.php
@@ -8,8 +8,8 @@
         <form method="POST" action="{{ route($route_base . '.income.add') }}">
             @csrf
             <div class="row">
-                <x-input.text m=6 l=6 id="comment" required text="Megjegyzés" />
-                <x-input.text type="number" m=6 l=6 id="amount" min=0 required text="Összeg" />
+                <x-input.text m=6 l=6 id="income-comment" name="comment" required text="Megjegyzés" />
+                <x-input.text type="number" m=6 l=6 id="income-amount" name="amount" min=0 required text="Összeg" />
             </div>
             <x-input.button floating class="btn-large right" icon="payments" />
         </form>


### PR DESCRIPTION
Without this change, clicking an input field in the "Kiadás hozzáadása" section would trigger the respective field in the "Bevétel hozzáadása" section, as the IDs of the input fields were the same.

This commit adds prefixes to the IDs to indicate which form they belong to, while keeping the old "name" attributes to avoid having to change the backend code.
