### PR TITLE
Adding modal dialogs to fault report buttons of items to make them more intuitive

### DIFF
--- a/app/Http/Controllers/Dormitory/Reservations/ReservableItemController.php
+++ b/app/Http/Controllers/Dormitory/Reservations/ReservableItemController.php
@@ -114,11 +114,16 @@ class ReservableItemController extends \App\Http\Controllers\Controller
 
     /**
      * Sends admins and staff an email notification
-     * about an allegedly faulty item.
+     * about an allegedly faulty item,
+     * with a message provided in a modal dialog.
      */
-    public function reportFault(ReservableItem $item)
+    public function reportFault(ReservableItem $item, Request $request)
     {
         $this->authorize('view', $item);
+
+        $validatedData = $request->validate([
+            'message' => 'nullable|max:2047'
+        ]);
 
         $thoseToNotify = User::whereHas('roles', function ($query) {
             $query->whereIn('name', [Role::SYS_ADMIN, Role::STAFF]);
@@ -128,7 +133,8 @@ class ReservableItemController extends \App\Http\Controllers\Controller
                 new ReportReservableItemFault(
                     $item,
                     $toNotify->name,
-                    user()->name
+                    user()->name,
+                    $validatedData['message']
                 )
             );
         }

--- a/app/Mail/Reservations/ReportReservableItemFault.php
+++ b/app/Mail/Reservations/ReportReservableItemFault.php
@@ -20,15 +20,17 @@ class ReportReservableItemFault extends Mailable
     public ReservableItem $item;
     public string $recipient;
     public string $reporter;
+    public ?string $message; // this is an explanation of the problem provided via a modal dialog
 
     /**
      * Create a new message instance.
      */
-    public function __construct(ReservableItem $item, string $recipient, string $reporter)
+    public function __construct(ReservableItem $item, string $recipient, string $reporter, ?string $message)
     {
         $this->item = $item;
         $this->recipient = $recipient;
         $this->reporter = $reporter;
+        $this->message = $message;
     }
 
     /**

--- a/resources/lang/en/reservations.php
+++ b/resources/lang/en/reservations.php
@@ -7,6 +7,7 @@ return [
     'bad_for_non-recurring' => 'Bad request for non-recurring reservation.',
     'check_reservations' => 'Please organize your reservations accordingly.',
     'create' => 'New reservation', // page title in breadcrumb
+    'describe_what_happened' => 'Describe what happened in a few sentences.',   // when reporting a fault
     'edit' => 'Edit reservation', // a page title
     'edit_all' => 'For all reservations',
     'edit_all_after' => 'For this reservation and all after this one',

--- a/resources/lang/hu/reservations.php
+++ b/resources/lang/hu/reservations.php
@@ -7,6 +7,7 @@ return [
     'bad_for_non-recurring' => 'Nem ismétlődő foglaláshoz ez érvénytelen kérés.',
     'check_reservations' => 'Kérjük, ennek megfelelően tervezze újra foglalásait.',
     'create' => 'Új foglalás', // page title in breadcrumb
+    'describe_what_happened' => 'Pár mondatban írja le, mi történt.',   // when reporting a fault
     'edit' => 'Foglalás szerkesztése', // a page title
     'edit_all' => 'Minden foglalásra',
     'edit_all_after' => 'Erre és minden későbbi foglalásra',

--- a/resources/sass/materialize.scss
+++ b/resources/sass/materialize.scss
@@ -39,6 +39,10 @@ i.material-icons {
 .card a {
     text-decoration: underline;
 }
+/* but not a-based buttons */
+.card a.btn {
+    text-decoration: none;
+}
 
 blockquote {
     margin: 20px 0;
@@ -299,6 +303,11 @@ body.dark a.btn {
     padding-right: 5px;
     border-top: solid 1px black;
     box-sizing: border-box;
+}
+
+// for footers of modal dialogs
+.modal .modal-footer {
+    height: unset;
 }
 
 @mixin column-count($ct) {

--- a/resources/sass/materialize.scss
+++ b/resources/sass/materialize.scss
@@ -307,7 +307,7 @@ body.dark a.btn {
 
 // for footers of modal dialogs
 .modal .modal-footer {
-    height: unset;
+    height: auto;
 }
 
 @mixin column-count($ct) {

--- a/resources/views/dormitory/reservations/item_table.blade.php
+++ b/resources/views/dormitory/reservations/item_table.blade.php
@@ -7,7 +7,7 @@
             <th style="max-width: 30%;">@lang('reservations.item_status')</th>
             <th style="text-align: right;">@lang('reservations.item_name')</th>
             {{-- for fault report buttons --}}
-            <th style="max-width: 10%;"></th>
+            <th style="width: 250px;"></th>
         </tr>
     </thead>
     <tbody>
@@ -32,11 +32,11 @@
                 action="{{ route('reservations.items.report_fault', ['item' => $item]) }}"
                 enctype='multipart/form-data'>
                     @csrf
-                    <x-input.button floating @class([
-                        'right', 'btn-small',
-                        'red' => !$item->out_of_order,
-                        'green' => $item->out_of_order
-                    ]) icon="build" />
+                    <x-input.button @class([
+                        'right',
+                        'coli' => !$item->out_of_order,
+                        'blue' => !$item->out_of_order,
+                    ]) :text="__($item->out_of_order ? 'reservations.report_fix' : 'reservations.report_fault')" />
                 </form>
             </td>
         </tr>

--- a/resources/views/dormitory/reservations/item_table.blade.php
+++ b/resources/views/dormitory/reservations/item_table.blade.php
@@ -28,18 +28,49 @@
                 </a>
             </td>
             <td>
+                {{-- The button triggers a modal dialog in which the user can provide an explanation about the problem. --}}
+
+                {{-- modal trigger --}}
+                <a @class([
+                    'btn',
+                    'waves-effect',
+                    'waves-light',
+                    'modal-trigger',
+                    'right',
+                    'coli' => !$item->out_of_order,
+                    'blue' => !$item->out_of_order,
+                ]) class="" href="#fault-reporting-modal-{{ $item->id }}">{{ __($item->out_of_order ? 'reservations.report_fix' : 'reservations.report_fault') }}</a>
+
+                {{-- modal structure --}}
                 <form method="POST"
                 action="{{ route('reservations.items.report_fault', ['item' => $item]) }}"
                 enctype='multipart/form-data'>
                     @csrf
-                    <x-input.button @class([
-                        'right',
-                        'coli' => !$item->out_of_order,
-                        'blue' => !$item->out_of_order,
-                    ]) :text="__($item->out_of_order ? 'reservations.report_fix' : 'reservations.report_fault')" />
+                    <div id="fault-reporting-modal-{{ $item->id }}" class="modal">
+                        <div class="modal-content">
+                            <h4>{{ __($item->out_of_order ? 'reservations.report_fix' : 'reservations.report_fault') }}</h4>
+                            <x-input.textarea id="message"
+                                      :text="__('general.description')"
+                                      :helper="__('reservations.describe_what_happened')"/>
+                        </div>
+                        <div class="modal-footer">
+                            <a href="#!" type="submit" class="waves-effect btn modal-close">@lang('general.cancel')</a>
+                            <button class="waves-effect btn modal-close" type="submit">@lang('general.send')</button>
+                        </div>
+                    </div>
                 </form>
+
             </td>
         </tr>
         @endforeach
     </tbody>
 </table>
+
+@push('scripts')
+<script>
+// for the modal dialogs
+$(document).ready(function(){
+    $('.modal').modal();
+});
+</script>
+@endpush

--- a/resources/views/emails/reservations/report_reservable_item_fault.blade.php
+++ b/resources/views/emails/reservations/report_reservable_item_fault.blade.php
@@ -14,6 +14,10 @@
         @else
         használhatatlannak tűnik.
         @endif
+    </p>
+    <p>A probléma részletes leírása:</p>
+    <blockquote>{{ $message }}</blockquote>
+    <p>
         Kérjük, ellenőrizze, hogy valóban ez-e a helyzet;
         ha igen, <a href="{{ route('reservations.items.show', ['item' => $item]) }}">jelölje meg itt</a>.
     </p>

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -845,7 +845,8 @@ class ReservationTest extends TestCase
                 ]);
 
                 $response = $this->actingAs($collegist)->followingRedirects()->post(
-                    route('reservations.items.report_fault', $item)
+                    route('reservations.items.report_fault', $item),
+                    ['message' => null]
                 );
                 $response->assertStatus(200);
                 $item->refresh();


### PR DESCRIPTION
The first weeks have shown that many users did not understand how these buttons worked (e.g. they reported a fault for the wrong machine). This will hopefully help.

![grafik](https://github.com/user-attachments/assets/413bbfbb-b3d3-4bb7-b23e-255fdbaab26e)

![grafik](https://github.com/user-attachments/assets/e0cadd88-4412-4403-bd8e-ff138894df13)

![grafik](https://github.com/user-attachments/assets/e7acabd0-2bae-4a7f-bad6-d72da8e6fee2)