### PR TITLE
Fixing bug with e-mail notifications on toggling items' out-of-order status

### DIFF
--- a/app/Http/Controllers/Dormitory/Reservations/ReservableItemController.php
+++ b/app/Http/Controllers/Dormitory/Reservations/ReservableItemController.php
@@ -147,7 +147,7 @@ class ReservableItemController extends \App\Http\Controllers\Controller
 
         $item->update(['out_of_order' => !$item->out_of_order]);
 
-        foreach ($item->usersWithActiveReservation as $toNotify) {
+        foreach ($item->usersWithActiveReservation()->get() as $toNotify) {
             Mail::to($toNotify)->queue(new ReservationAffected(
                 $item,
                 $toNotify->name

--- a/app/Models/Reservations/ReservableItem.php
+++ b/app/Models/Reservations/ReservableItem.php
@@ -47,10 +47,12 @@ class ReservableItem extends Model
     /**
      * The users who currently have a reservation for this item.
      */
-    public function usersWithActiveReservation(): BelongsToMany
+    public function usersWithActiveReservation()
     {
-        return $this->belongsToMany(User::class, Reservation::class, 'reservable_item_id', 'user_id')
-            ->wherePivot('reserved_until', '>', Carbon::now());
+        return User::whereHas('reservations', function ($query) {
+            $query->where('reservable_item_id', $this->id)
+                ->where('reserved_until', '>', Carbon::now());
+        });
     }
 
     /**


### PR DESCRIPTION
Fixing a bug because of which users with past reservations also got notified when toggling out-of-order status.
