### PR TITLE
Use periodic events for KKT/Netreg

### DIFF
--- a/app/Http/Controllers/Network/AdminInternetController.php
+++ b/app/Http/Controllers/Network/AdminInternetController.php
@@ -25,9 +25,7 @@ class AdminInternetController extends Controller
     {
         $this->authorize('handleAny', InternetAccess::class);
 
-        return view('network.admin.app', [
-            'activation_date' => InternetAccess::getInternetDeadline()->format('Y-m-d H:i'),
-        ]);
+        return view('network.admin.app');
     }
 
     /**
@@ -46,7 +44,7 @@ class AdminInternetController extends Controller
                 ->select('internet_accesses.*')
                 ->with('user')
         )
-            ->sortable(['auto_approved_mac_slots', 'has_internet_until', 'user.name'])
+            ->sortable(['auto_approved_mac_slots', 'has_internet_until', 'user.name', 'netreg_paid'])
             ->filterable(['auto_approved_mac_slots', 'has_internet_until', 'user.name'])
             ->paginate();
 
@@ -84,10 +82,10 @@ class AdminInternetController extends Controller
         $this->authorize('extend', $internetAccess);
 
         $request->validate([
-            'has_internet_until' => 'nullable|date',
+            'has_internet_until' => 'date',
         ]);
 
-        return $internetAccess->extendInternetAccess($request->get('has_internet_until'));
+        return $internetAccess->extendInternetAccess(Carbon::parse($request->get('has_internet_until')));
     }
 
     /**

--- a/app/Models/Internet/InternetAccess.php
+++ b/app/Models/Internet/InternetAccess.php
@@ -128,7 +128,7 @@ class InternetAccess extends Model
     }
 
     /**
-     * @param string|Carbon|null $newDate
+     * @param Carbon $newDate
      * @return Carbon
      */
     public function extendInternetAccess(Carbon $newDate): Carbon

--- a/database/migrations/2024_09_29_103107_add_internet_paid_field_to_internet_accesses.php
+++ b/database/migrations/2024_09_29_103107_add_internet_paid_field_to_internet_accesses.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_09_29_103107_add_internet_paid_field_to_internet_accesses.php
+++ b/database/migrations/2024_09_29_103107_add_internet_paid_field_to_internet_accesses.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('internet_accesses', function (Blueprint $table) {
+            $table->boolean('netreg_paid')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('internet_accesses', function (Blueprint $table) {
+            $table->dropColumn('netreg_paid');
+        });
+    }
+};

--- a/resources/views/network/admin/internet_access.blade.php
+++ b/resources/views/network/admin/internet_access.blade.php
@@ -1,8 +1,6 @@
 <span class="card-title">Internetelérés</span>
 <blockquote>
-    <p>Az aktuális internetelérés határidő: <span class="coli-text text-orange">{{ $activation_date }}</span></p>
-    <p>Collegisták esetén a Netreg befizetésekor automatikusan beállítja a rendszer a hozzáférésüket eddig a
-        dátumig.</p>
+    <p>Collegisták esetén a Netreg befizetésekor automatikusan beállítja a rendszer a hozzáférésüket a következő periódusig.</p>
     <p>Vendégek esetén belépéskor meg kell adniuk a kiköltözés dátumát, amihez szinkronizáljuk az internet
         hozzáférésüket. Ha egy volt colis kér netet, csak adj neki vendég jogosultságot, és első belépéskor be tudja
         állítani már a netet magának.</p>
@@ -16,21 +14,7 @@
 <script type="text/javascript" src="{{ mix('js/moment.min.js') }}"></script>
 <script type="application/javascript">
     $(document).ready(function () {
-            var activation_date = new Date("{{ $activation_date }}");
             var now = new Date();
-            var extendAction = function (cell, formatterParams, onRendered) {
-                var data = cell.getRow().getData();
-                var active = (new Date(data.has_internet_until))
-                onRendered(function () {
-                    $('.tooltipped').tooltip();
-                });
-                return $(`<button class="btn-floating tooltipped" style="margin-right: 10px" data-position="top" data-tooltip="Meghosszabbít: {{$activation_date}}">
-                            <i class="material-icons">update</i></button>
-                        `)
-                    .click(function () {
-                        sendExtendRequest(cell, data.user_id, "{{ $activation_date }}");
-                    }).toggle(data.has_internet_until == null || active < activation_date)[0];
-            };
 
             var revokeAction = function (cell, formatterParams, onRendered) {
                 var data = cell.getRow().getData();
@@ -57,7 +41,7 @@
                 if (value) {
                     value = moment(value).format("YYYY. MM. DD. HH:mm");
                 } else {
-                    value = 'Nincs hozzáférés'
+                    value = 'N/A'
                 }
                 const data = cell.getRow().getData();
                 return $("<input type=\"text\" class=\"datepicker\" value=\"" + value + "\"/>")
@@ -134,13 +118,17 @@
                         minWidth: 150,
                     },
                     {
-                        title: "Internetelérés",
+                        title: "Netreg fizetett",
+                        field: "netreg_paid",
+                        minWidth: 50,
+                    },
+                    {
+                        title: "Egyéni hozzáférés eddig",
                         field: "has_internet_until",
                         sorter: "datetime",
                         formatter: dateFormatter,
                         minWidth: 50,
                     },
-                    {title: "", field: "state", headerSort: false, formatter: extendAction, width: 80},
                     {title: "", field: "state", headerSort: false, formatter: revokeAction, width: 80},
                 ],
                 ajaxResponse: function (url, params, response) {

--- a/resources/views/student-council/economic-committee/app.blade.php
+++ b/resources/views/student-council/economic-committee/app.blade.php
@@ -11,6 +11,7 @@
 <div class="row">
     <div class="col s12">
         @include('utils.checkout.status')
+        @include('student-council.economic-committee.period')
         <div class="row">
             @can('addKKTNetreg', \App\Models\Checkout::class)
             <div class="col s12">
@@ -29,7 +30,7 @@
                                         A Netreg tranzakcióid a <a href="{{route('admin.checkout')}}"> rendszergazdai kasszában</a> láthatod.
                                     </blockquote>
                                     @can('administrate', $checkout)
-                                    <blockquote>A gazdasági alelnök, a kulturális bizottság tagjai és a rendszergazdák szedhetnek be KKT-t/Netreget. Ezeket a tranzakciókat a tartozások alatt találod.</blockquote>
+                                    <blockquote>A gazdasági alelnök, a rendszergazdák, és a KKT jogosultsággal rendelkező collegisták szedhetnek be KKT-t/Netreget. Ezeket a tranzakciókat a tartozások alatt találod.</blockquote>
                                     @endcan
                                     <x-input.select l=4 :elements="$users_not_paid" id="user_id" text="general.user" :formatter="function($user) { return $user->uniqueName; }" />
                                     <x-input.text  m=6 l=4 id="kkt" text="KKT" type="number" required min="0" :value="config('custom.kkt')" />

--- a/resources/views/student-council/economic-committee/period.blade.php
+++ b/resources/views/student-council/economic-committee/period.blade.php
@@ -1,0 +1,25 @@
+@can('administrate', $checkout)
+    <div class="card">
+        <form action="{{route('kktnetreg.period.update')}}" method="POST">
+            @csrf
+            <div class="card-content">
+                <div class="card-title">
+                    KKT / Netreg fizetés időszak
+                </div>
+                @if($periodicEvent?->isActive())
+                    <blockquote>Jelenleg a KKT/Netreg fizetési időszak aktív. A határidő: {{$periodicEvent?->endDate()}}. </blockquote>
+                @else
+                    <blockquote>Jelenleg a KKT/Netreg fizetési időszak nem aktív. Az aktiváláshoz add meg a határidőt, ami az internet hozzáférés vége lesz.</blockquote>
+                    <div class="row">
+                        <!-- These are using html datetime-local attribute because we don't have datetime picker. The labels are not compatible with our components. -->
+                        <x-input.select m="3" id="semester_id" :elements="\App\Models\Semester::all()" :value="$periodicEvent?->semester_id" :default="\App\Models\Semester::current()->id" helper="Szemeszter"/>
+                        <x-input.text m="3" id="end_date" type="datetime-local" without-label helper="Határidő" :value="$periodicEvent?->end_date"/>
+                    </div>
+                    <blockquote class="error">Megnyitás után a határidő nem módosítható, de a határidő lejárata után is lehet még fizetést felvinni.</blockquote>
+
+                    <x-input.button floating class="right" icon="save"/>
+                @endif
+            </div>
+        </form>
+    </div>
+@endcan

--- a/routes/web.php
+++ b/routes/web.php
@@ -225,6 +225,7 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
     Route::post('/economic_committee/mark_as_paid/{user}', [EconomicController::class, 'markAsPaid'])->name('economic_committee.pay');
     Route::post('/economic_committee/to_checkout', [EconomicController::class, 'toCheckout'])->name('economic_committee.to_checkout');
 
+    Route::post('/admission/kktnetreg/period/update', [EconomicController::class, 'updatePaymentPeriod'])->name('kktnetreg.period.update');
     Route::get('/economic_committee/kktnetreg', [EconomicController::class, 'indexKKTNetreg'])->name('kktnetreg');
     Route::post('/economic_committee/kktnetreg/pay', [EconomicController::class, 'payKKTNetreg'])->name('kktnetreg.pay');
     Route::get('/economic_committee/calculate_workshop_balance', [EconomicController::class, 'calculateWorkshopBalance'])->name('economic_committee.workshop_balance');

--- a/tests/Feature/AdminInternetControllerTest.php
+++ b/tests/Feature/AdminInternetControllerTest.php
@@ -118,24 +118,6 @@ class AdminInternetControllerTest extends TestCase
     }
 
     /**
-     * Test that an admin can extend an internet access to the default value.
-     */
-    public function test_extend_internet_access_default(): void
-    {
-        $date = InternetAccess::getInternetDeadline();
-        $response = $this->actingAs($this->admin)->post(route('internet.internet_accesses.extend', $this->user->internetAccess));
-
-        $response->assertStatus(200);
-
-        $this->assertDatabaseHas('internet_accesses', [
-            'user_id' => $this->user->id,
-            'has_internet_until' => $date,
-        ]);
-
-        $response->assertSee($date->format('Y-m-d'));
-    }
-
-    /**
      * Test that an admin can revoke an internet access.
      */
 


### PR DESCRIPTION
Some thing that was missing before.
I'm merging to https://github.com/EotvosCollegium/mars/pull/555, you can check both PRs.

When a KKT/Netreg period opens, now the collegists 'netreg_paid' will be set to false, and they have internet only until the payment deadline. If they pay, the netreg_paid=true will overwrite the deadline.


