### PR TITLE
Allow all student council members to view users

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -35,7 +35,7 @@ class UserPolicy
             Role::SECRETARY,
             Role::DIRECTOR,
             Role::STUDENT_COUNCIL_SECRETARY,
-            Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS,
+            Role::STUDENT_COUNCIL => array_merge(Role::STUDENT_COUNCIL_LEADERS, Role::COMMITTEE_LEADERS),
         ]);
     }
 
@@ -68,7 +68,7 @@ class UserPolicy
                 Role::WORKSHOP_ADMINISTRATOR,
                 Role::WORKSHOP_LEADER,
                 Role::STUDENT_COUNCIL_SECRETARY,
-                Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS,
+                Role::STUDENT_COUNCIL => array_merge(Role::STUDENT_COUNCIL_LEADERS, Role::COMMITTEE_LEADERS),
             ]);
     }
 
@@ -102,7 +102,7 @@ class UserPolicy
                 return $user->hasRole([
                     Role::SECRETARY,
                     Role::DIRECTOR,
-                    Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS,
+                    Role::STUDENT_COUNCIL => array_merge(Role::STUDENT_COUNCIL_LEADERS, Role::COMMITTEE_LEADERS),
                     Role::STUDENT_COUNCIL_SECRETARY,
                 ]);
             })) || $target->workshops


### PR DESCRIPTION
Other members of the student council might have legitimate reasons to view collegists' data (e.g. to obtain contact information). This policy change was approved by the director.

