### PR TITLE
Remove the ability to mix free and paid pages

### DIFF
--- a/app/Utils/Printer.php
+++ b/app/Utils/Printer.php
@@ -41,19 +41,29 @@ class Printer
 
         // If using free pages, check the amount that can be used
         if ($this->use_free_pages) {
+            $this->pages *= $this->number_of_copies;
+
             $this->calculateFreePagePool();
+
+            if ($this->pages > 0) {
+                return back()->withInput()->with('error', __('print.no_balance'));
+            }
+
+            // Print document
+            return $this->printDocument();
+        } else {
+
+            // Calculate cost
+            $this->cost = PrintAccount::getCost($this->pages, $this->is_two_sided, $this->number_of_copies);
+
+            // Check balance
+            if (!$this->print_account->hasEnoughMoney($this->cost)) {
+                return back()->withInput()->with('error', __('print.no_balance'));
+            }
+
+            // Print document
+            return $this->printDocument();
         }
-
-        // Calculate cost
-        $this->cost = PrintAccount::getCost($this->pages, $this->is_two_sided, $this->number_of_copies);
-
-        // Check balance
-        if (!$this->print_account->hasEnoughMoney($this->cost)) {
-            return back()->withInput()->with('error', __('print.no_balance'));
-        }
-
-        // Print document
-        return $this->printDocument();
     }
 
     /**

--- a/app/Utils/Printer.php
+++ b/app/Utils/Printer.php
@@ -18,7 +18,7 @@ class Printer
     private $number_of_copies;
     private $use_free_pages;
     private $print_account;
-    private $free_page_pool = [];
+    private $free_page_update = [];
     private $cost = 0;
 
     public function __construct($filename, $path, $use_free_pages = false, $is_two_sided = true, $number_of_copies = 1)
@@ -41,11 +41,8 @@ class Printer
 
         // If using free pages, check the amount that can be used
         if ($this->use_free_pages) {
-            $this->pages *= $this->number_of_copies;
 
-            $this->calculateFreePagePool();
-
-            if ($this->pages > 0) {
+            if (!$this->planFreePageUsage()) {
                 return back()->withInput()->with('error', __('print.no_balance'));
             }
 
@@ -69,31 +66,27 @@ class Printer
     /**
      * Only calculating the values here to see how many pages can be covered free of charge.
      */
-    private function calculateFreePagePool()
+    private function planFreePageUsage()
     {
-        $this->free_page_pool = [];
-        $available_pages = 0;
+        $requested_pages = $this->number_of_copies * $this->pages;
+        $this->free_page_update = [];
+        $deducted_pages = 0;
         $all_pages = user()->freePages
             ->where('deadline', '>', Carbon::now())
             ->sortBy('deadline');
 
         foreach ($all_pages as $key => $free_page) {
-            if ($available_pages + $free_page->amount >= $this->pages) {
-                $this->free_page_pool[] = [
-                    'page' => $free_page,
-                    'new_amount' => $free_page->amount - ($this->pages - $available_pages)
-                ];
-                $available_pages = $this->pages;
+            $deduce_from_current = min($requested_pages - $deducted_pages, $free_page->amount);
+            $this->free_page_update[] = [
+                'page' => $free_page,
+                'new_amount' => $free_page->amount - $deduce_from_current
+            ];
+            $deducted_pages += $deduce_from_current;
+            if($deducted_pages == $requested_pages) {
                 break;
             }
-            $this->free_page_pool[] = [
-                'page' => $free_page,
-                'new_amount' => 0
-            ];
-            $available_pages += $free_page->amount;
         }
-
-        $this->pages -= $available_pages;
+        return $deducted_pages == $requested_pages;
     }
 
     private function printDocument()
@@ -105,7 +98,7 @@ class Printer
 
         // Update print account history
         $this->print_account->update(['last_modified_by' => user()->id]);
-        foreach ($this->free_page_pool as $fp) {
+        foreach ($this->free_page_update as $fp) {
             $fp['page']->update([
                 'amount' => $fp['new_amount'],
                 'last_modified_by' => user()->id

--- a/resources/lang/en/print.php
+++ b/resources/lang/en/print.php
@@ -43,6 +43,7 @@ return [
     'number_of_copies' => 'Number of copies',
     'number_of_printed_documents' => 'Number of printed documents',
     'options' => 'Printing options',
+    'payment_methods_cannot_be_mixed' => 'A print job can be either free or paid as they cannot be mixed.',
     'pdf_description' => 'Only .pdf files can be printed.',
     'pdf_maxsize' => 'The maximum file size is :maxsize MB.',
     'print' => 'Print',

--- a/resources/lang/hu/print.php
+++ b/resources/lang/hu/print.php
@@ -43,6 +43,7 @@ return [
     'number_of_copies' => 'Példányszám',
     'number_of_printed_documents' => 'Nyomtatott dokumentumok száma',
     'options' => 'Beállítások',
+    'payment_methods_cannot_be_mixed' => 'Egy nyomtatás vagy ingyenes vagy fizetős lehet, nem keverhető.',
     'pdf_description' => 'Csak .pdf fájl nyomtatható.',
     'pdf_maxsize' => 'A fájl mérete legfeljebb :maxsize MB lehet.',
     'print' => 'Nyomtatás',

--- a/resources/views/dormitory/print/print.blade.php
+++ b/resources/views/dormitory/print/print.blade.php
@@ -10,6 +10,9 @@
             @lang('print.available_money'): <b class="coli-text text-orange"> {{ user()->printAccount->balance }}</b> HUF.
             @lang('print.upload_money')
             </p>
+            <p>
+            @lang('print.payment_methods_cannot_be_mixed')
+            </p>
         </blockquote>
         <form class="form-horizontal" role="form" method="POST" action="{{ route('print.print') }}"
             enctype="multipart/form-data">


### PR DESCRIPTION
## Description
There is a quite annoying bug where if a user prints using free pages, their free page pool is only decreased by p and not by n*p (where n is the number of copies, and p is the number of pages in the document). The quickest and easiest way of dealing with it is to only allow a print job to be fully paid or entirely free and deduct the printed pages correctly. The solution is not ideal but it is quite a rare occurrence where someone would like to use both free pages and pay for the remainder. (They can split it themselves.)

This bug is quite annoying as our registry shows only a fraction of the actual usage. I.e. ~ 5000 sheets was loaded into the printer during this semester, and our Mars instance shows only a few hundred printed pages. It would be crucial to understand how many pages were printed for different kinds of activities as it has already eaten roughly a quarter of our budget of the semester in half-a-semester.

## Changes

- Removed the ability to mix free and paid pages.
- Fixed the problem where multiple number of copies were only deducted once.

## Additional Notes
I am not refactoring the printer module for this PR.
To allow mixing these methods, the `PrintAccount` class would also need to be refactored but I do not think that it is worth the time to be invested as we will need additional refactoring as we are planning on introducing multiple printers.