### PR TITLE
Upgrading docker-dev-setup to Ubuntu 24.04

### DIFF
--- a/docker-dev-setup/Dockerfile
+++ b/docker-dev-setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 WORKDIR /workspace
 
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y curl tar xz-utils iputils-ping composer poppler-utils cups-client cm-super \
                           libzip-dev libpng-dev libonig-dev libcurl4-openssl-dev libxml2-dev \
-                          php8.2-cli php8.2-mysql php8.2-zip php8.2-gd php8.2-mbstring php8.2-curl php8.2-xml php8.2-bcmath \
+                          php8.3-cli php8.3-mysql php8.3-zip php8.3-gd php8.3-mbstring php8.3-curl php8.3-xml php8.3-bcmath \
                           texlive-latex-base texlive-latex-extra texlive-lang-european \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Ubuntu 23.10 is EOL. For this reason docker-dev-setup no longer worked. Fixed by upgrading to 24.04 and PHP 8.3.

