### PR TITLE
Fixes for print refactoring

### DIFF
--- a/app/Console/Commands.php
+++ b/app/Console/Commands.php
@@ -18,7 +18,7 @@ class Commands
         }
 
         $process = Process::fromShellCommandline(config('commands.ping') . " $router->ip -c 1 | grep 'error\|unreachable'");
-        $process->run();
+        $process->run($log = false);
         $result = $process->getOutput(debugOutput: rand(1, 10) > 9 ? "error" : '');
         return $result;
     }

--- a/app/Console/Commands.php
+++ b/app/Console/Commands.php
@@ -13,7 +13,7 @@ class Commands
 {
     public static function pingRouter($router)
     {
-        if (preg_match('/[a-zA-Z]/', $router->ip)) {
+        if (!preg_match('^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$', $router->ip)) {
             throw new \InvalidArgumentException("Invalid IP address: " . $router->ip);
         }
 

--- a/app/Http/Controllers/Secretariat/DocumentController.php
+++ b/app/Http/Controllers/Secretariat/DocumentController.php
@@ -158,7 +158,7 @@ class DocumentController extends Controller
         // TODO: figure out result
         Commands::latexToPdf($pathTex, $outputDir);
 
-        if (config('app.debug')) {
+        if (config('app.debug') && !config('commands.run_in_debug')) {
             return $pathTex;
         } else {
             return $pathPdf;

--- a/app/Models/FreePages.php
+++ b/app/Models/FreePages.php
@@ -79,7 +79,7 @@ class FreePages extends Model
      * Wether the free pages are still available.
      * @return bool
      */
-    protected function available()
+    protected function available() : Attribute
     {
         return Attribute::make(
             get: fn () => now()->isBefore($this->deadline)

--- a/app/Models/PrintJob.php
+++ b/app/Models/PrintJob.php
@@ -97,7 +97,7 @@ class PrintJob extends Model
     /**
      * Attribute for the translated cost.
      */
-    public function translatedCost()
+    public function translatedCost() : Attribute
     {
         return Attribute::make(
             get: fn () => $this->used_free_pages ? "$this->cost ingyenes oldal" : "$this->cost HUF"
@@ -107,7 +107,7 @@ class PrintJob extends Model
     /**
      * Attribute for the translated state.
      */
-    public function translatedState()
+    public function translatedState() : Attribute
     {
         return Attribute::make(
             get: fn () => __("print." . strtoupper($this->state->value))

--- a/app/Utils/Process.php
+++ b/app/Utils/Process.php
@@ -7,6 +7,7 @@ use Symfony\Component\Process\Process as SymfonyProcess;
 
 class Process extends SymfonyProcess
 {
+
     /**
      * Run the process. If the app is in debug mode, the process will not be executed.
      *
@@ -14,10 +15,18 @@ class Process extends SymfonyProcess
      * @param array $env
      * @return int
      */
-    public function run(?callable $callback = null, array $env = []): int
+    public function run(?callable $callback = null, array $env = [], bool $log = true): int
     {
         if (config('app.debug') === false || config('commands.run_in_debug') === true) {
-            return parent::run($callback, $env);
+            $return_value = parent::run($callback, $env);
+            if($log) {
+                if($return_value === 0) {
+                    Log::info("Command: " . $this->getCommandLine() . " executed successfully.");
+                } else {
+                    Log::error("Command: " . $this->getCommandLine() . " failed with error code: " . $return_value . "\nWith output: " . $this->getOutput() . " and error output: " . $this->getErrorOutput());
+                }
+            }
+            return $return_value;
         }
         Log::info("Process not executed in debug mode.");
         return 0;

--- a/database/factories/PrintJobFactory.php
+++ b/database/factories/PrintJobFactory.php
@@ -13,6 +13,7 @@ class PrintJobFactory extends Factory
     public function definition()
     {
         return [
+            'printer_id' => 1,
             'filename' => $this->faker->text,
             'state' => $this->faker->randomElement(PrintJobStatus::cases()),
             'job_id' => $this->faker->randomNumber,

--- a/database/migrations/2019_10_13_130718_create_roles_table.php
+++ b/database/migrations/2019_10_13_130718_create_roles_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Role;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -22,8 +21,8 @@ class CreateRolesTable extends Migration
         });
 
         // Adding roles
-        foreach (Role::ALL as $key => $role) {
-            DB::table('roles')->insert(['name' => $role]);
+        foreach (['sys-admin', 'collegist', 'tenant', 'workshop-administrator', 'workshop-leader', 'application-committee', 'aggregated-application-committee', 'secretary', 'director', 'staff', 'printer', 'locale-admin', 'student-council', 'student-council-secretary', 'board-of-trustees-member', 'ethics-commissioner', 'alumni', 'receptionist'] as $role_name) {
+            DB::table('roles')->insert(['name' => $role_name]);
         }
     }
 

--- a/database/migrations/2024_12_25_112824_remove_printer_role.php
+++ b/database/migrations/2024_12_25_112824_remove_printer_role.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $printer_role_id = DB::table('roles')->where('name', 'printer')->first()->id;
+
+        DB::table('role_users')->where('role_id', $printer_role_id)->delete();
+
+        DB::table('roles')->where('name', 'printer')->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $printer_role_id = DB::table('roles')->insertGetId([
+            'name' => 'printer'
+        ]);
+        
+        foreach(DB::table('users')->where('verified', 1)->get() as $user){
+            DB::table('role_users')->insert([
+                'role_id' => $printer_role_id,
+                'user_id' => $user->id
+            ]);
+        }
+    }
+};

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Semester;
 use App\Models\Checkout;
 use App\Models\Faculty;
 use App\Models\FreePages;
@@ -27,6 +28,8 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
+        Semester::current(); // generate current semester if still not exists
+
         $this->createSuperUser();
         $this->createStaff();
 

--- a/resources/views/dormitory/print/app.blade.php
+++ b/resources/views/dormitory/print/app.blade.php
@@ -9,10 +9,10 @@
         @include("dormitory.print.print")
     </div>
     <div class="col s12">
-        @include("dormitory.print.history", ['route' => route('print-job.index'), 'admin' => false])
+        @include("dormitory.print.history", ['route' => route('print.print-job.index'), 'admin' => false])
     </div>
     <div class="col s12">
-        @include("dormitory.print.free", ['route' => route('free-pages.index'), 'admin' => false])
+        @include("dormitory.print.free", ['route' => route('print.free-pages.index'), 'admin' => false])
     </div>
     <div class="col s12">
         @include("dormitory.print.send")

--- a/resources/views/dormitory/print/history.blade.php
+++ b/resources/views/dormitory/print/history.blade.php
@@ -13,7 +13,7 @@
                     ).click(function() {
                         $.ajax({
                             type: "PUT",
-                            url: "{{ route('print-job.update', [':job', 'state' => 'CANCELLED']) }}".replace(':job', data.id),
+                            url: "{{ route('print.print-job.update', [':job', 'state' => 'CANCELLED']) }}".replace(':job', data.id),
                             success: function() {
                                 cell.getTable().setPage(cell.getTable().getPage());
                             },

--- a/resources/views/dormitory/print/manage/account_history.blade.php
+++ b/resources/views/dormitory/print/manage/account_history.blade.php
@@ -14,7 +14,7 @@ $(document).ready(function() {
         columns: [
             {
                 title: "Felhasználó",
-                field: "user_name",
+                field: "user.name",
                 sorter: "string",
                 headerFilter: 'input',
                 minWidth:200
@@ -39,7 +39,7 @@ $(document).ready(function() {
             },
             {
                 title: "Módosító",
-                field: "modifier_name",
+                field: "modifier.name",
                 sorter: "string",
                 headerFilter: 'input',
                 minWidth:180

--- a/resources/views/dormitory/print/manage/account_history.blade.php
+++ b/resources/views/dormitory/print/manage/account_history.blade.php
@@ -6,7 +6,7 @@ $(document).ready(function() {
         paginationSize: 20,
         layout: "fitColumns",
         pagination: "remote", //enable remote pagination
-        ajaxURL: "{{ route('print-account-history.index') }}", //set url for ajax request
+        ajaxURL: "{{ route('print.print-account-history.index') }}", //set url for ajax request
         ajaxSorting: true,
         ajaxFiltering: true,
         placeholder: "@lang('general.nothing_to_show')",

--- a/resources/views/dormitory/print/manage/app.blade.php
+++ b/resources/views/dormitory/print/manage/app.blade.php
@@ -30,10 +30,10 @@
         </div>
     </div>
     <div class="col s12">
-        @include("dormitory.print.free", ['route' => route('free-pages.index.admin'), 'admin' => true])
+        @include("dormitory.print.free", ['route' => route('print.free-pages.index.admin'), 'admin' => true])
     </div>
     <div class="col s12">
-        @include("dormitory.print.history", ['route' => route('print-job.index.admin'), 'admin' => true])
+        @include("dormitory.print.history", ['route' => route('print.print-job.index.admin'), 'admin' => true])
     </div>
 </div>
 

--- a/resources/views/dormitory/print/manage/free.blade.php
+++ b/resources/views/dormitory/print/manage/free.blade.php
@@ -1,7 +1,7 @@
 @can('create', \App\Models\FreePages::class)
 <span class="card-title">Ingyenes oldalak hozzáadása</span>
 <div class="row">
-    <form method="POST" action="{{ route('free-pages.store') }}">
+    <form method="POST" action="{{ route('print.free-pages.store') }}">
         @csrf
         <x-input.select l=3 :elements="$users" :formatter="function($user) { return $user->uniqueName; }" id="user_id" text="general.user"/>
         <x-input.text l=3 id="amount" type="number" min='1' text="print.quantity" required/>

--- a/resources/views/dormitory/print/manage/modify.blade.php
+++ b/resources/views/dormitory/print/manage/modify.blade.php
@@ -2,7 +2,7 @@
 <span class="card-title">Egyenleg módosítása</span>
 <blockquote>A tranzakció az admin kasszába fog kerülni.</blockquote>
 <div class="row">
-<form method="POST" action="{{ route('print-account.update') }}">
+<form method="POST" action="{{ route('print.print-account.update') }}">
         @csrf
         @method('PUT')
         <x-input.select l=5 id="user" text="general.user" :elements="$users" :formatter="fn($user) => $user->uniqueName"/>

--- a/resources/views/dormitory/print/print.blade.php
+++ b/resources/views/dormitory/print/print.blade.php
@@ -23,7 +23,7 @@
             @lang('print.payment_methods_cannot_be_mixed')
             </p>
         </blockquote>
-        <form class="form-horizontal" role="form" method="POST" action="{{ route('print-job.store') }}" enctype="multipart/form-data">
+        <form class="form-horizontal" role="form" method="POST" action="{{ route('print.print-job.store') }}" enctype="multipart/form-data">
             @csrf
             <div class="row">
                 <x-input.file l=8 xl=10 id="file" accept=".pdf" required text="print.select_document"/>
@@ -50,7 +50,7 @@
                 </blockquote>
             </div>
             @if($printer->paper_out_at != null && $user->can('handleAny', \App\Models\PrintAccount::class))
-                <form method="POST" action="{{ route('printer.update', ['printer' => $printer->id]) }}">
+                <form method="POST" action="{{ route('print.update', ['printer' => $printer->id]) }}">
                     @method('PUT')
                     @csrf
                     <x-input.button l=3 class="right coli blue" text="Papír újratöltve"/>
@@ -58,7 +58,7 @@
                     <input name="no_paper" value="0" type="hidden" />
                 </form>
             @else
-                <form method="POST" action="{{ route('printer.update', ['printer' => $printer->id]) }}">
+                <form method="POST" action="{{ route('print.update', ['printer' => $printer->id]) }}">
                     @method('PUT')
                     @csrf
                     <x-input.button l=3 class="right coli blue" text="print.no_paper" />

--- a/resources/views/dormitory/print/send.blade.php
+++ b/resources/views/dormitory/print/send.blade.php
@@ -4,7 +4,7 @@
         <blockquote>
         @lang('print.how_transfer_works')
         </blockquote>
-        <form method="POST" action="{{ route('print-account.update') }}">
+        <form method="POST" action="{{ route('print.print-account.update') }}">
             @csrf
             @method('PUT')
             <div class="row">

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -37,7 +37,7 @@
     @if(Auth::user()?->verified)
         <!-- print page -->
         @can('use', \App\Models\PrintAccount::class)
-        <li><a class="waves-effect" href="{{ route('printer.index') }}"><i class="material-icons left">local_printshop</i>@lang('print.print')</a></li>
+        <li><a class="waves-effect" href="{{ route('print.index') }}"><i class="material-icons left">local_printshop</i>@lang('print.print')</a></li>
         @endif
         <!-- internet page -->
         <li><a class="waves-effect" href="{{ route('internet.index') }}"><i
@@ -171,7 +171,7 @@
                             <!-- print admin -->
                             @can('handleAny', \App\Models\PrintAccount::class)
                             <li>
-                                <a class="waves-effect" href="{{ route('printer.index.admin') }}">
+                                <a class="waves-effect" href="{{ route('print.index.admin') }}">
                                     <i class="material-icons left">local_printshop</i>Nyomtatás
                                 </a>
                             </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -127,22 +127,24 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
     });
 
     /** Printing */
-    Route::get('/printer', [PrinterController::class, 'index'])->name('printer.index');
-    Route::get('/printer/admin', [PrinterController::class, 'adminIndex'])->name('printer.index.admin');
-    Route::put('/printer/{printer}', [PrinterController::class, 'update'])->name('printer.update');
+    Route::prefix('print')->name('print.')->group(function(){
+        Route::get('/', [PrinterController::class, 'index'])->name('index');
+        Route::get('/admin', [PrinterController::class, 'adminIndex'])->name('index.admin');
+        Route::put('/{printer}', [PrinterController::class, 'update'])->name('update');
 
-    Route::get('/print-job', [PrintJobController::class, 'index'])->name('print-job.index');
-    Route::get('/print-job/admin', [PrintJobController::class, 'adminIndex'])->name('print-job.index.admin');
-    Route::post('print-job', [PrintJobController::class, 'store'])->name('print-job.store');
-    Route::put('/print-job/{job}', [PrintJobController::class, 'update'])->name('print-job.update');
+        Route::get('/print-job', [PrintJobController::class, 'index'])->name('print-job.index');
+        Route::get('/print-job/admin', [PrintJobController::class, 'adminIndex'])->name('print-job.index.admin');
+        Route::post('print-job', [PrintJobController::class, 'store'])->name('print-job.store');
+        Route::put('/print-job/{job}', [PrintJobController::class, 'update'])->name('print-job.update');
 
-    Route::get('/free-pages', [FreePagesController::class, 'index'])->name('free-pages.index');
-    Route::post('/free-pages', [FreePagesController::class, 'store'])->name('free-pages.store');
-    Route::get('/free-pages/admin', [FreePagesController::class, 'adminIndex'])->name('free-pages.index.admin');
+        Route::get('/free-pages', [FreePagesController::class, 'index'])->name('free-pages.index');
+        Route::post('/free-pages', [FreePagesController::class, 'store'])->name('free-pages.store');
+        Route::get('/free-pages/admin', [FreePagesController::class, 'adminIndex'])->name('free-pages.index.admin');
 
-    Route::put('/print-account', [PrintAccountController::class, 'update'])->name('print-account.update');
+        Route::put('/print-account', [PrintAccountController::class, 'update'])->name('print-account.update');
 
-    Route::get('/print-account-history', [PrintAccountHistoryController::class, 'index'])->name('print-account-history.index');
+        Route::get('/print-account-history', [PrintAccountHistoryController::class, 'index'])->name('print-account-history.index');
+    });    
 
     Route::prefix('internet')->name('internet.')->group(function () {
         Route::get('/', [InternetController::class, 'index'])->name('index');


### PR DESCRIPTION
## Description

There are some issues in #394 and this PR's aim is to deal with some of these issues. This is still a draft, the issues addressed:

- Printing role is not deleted from the database if it comes from the previous versions
- Minor issue with executing data as program
- Minor issue with attributes
- Log results of commands

## Changes

- ~~Removed all references of Models in migrations, fixed the issues caused by this change in seeders~~ Moving to #670 except for printer role
- Drop printer role in the database
- Better check for IP addresses
- Fixed the problems with attributes
- Log results of commands

## Additional Notes

Old migrations have been changed multiple times which is not great practice. Referencing Models in migrations should be avoided as changing the Model might change older migrations. Migrations are usually the "way of propagating changes you make to your Models (adding a field, deleting a model, etc.) into your database schema" (https://docs.djangoproject.com/en/5.1/topics/migrations/). Therefore migrations should never ever reference the Models as their main purpose is to have a migration between two different versions of models. Once a migration is written, they should usually never be edited in the future (unless the language / framework changes the syntax). But functionally a migration should remain the same in its whole life regardless of how the application is developed.

~~Changing so many migrations should probably not be part of just a patch to another PR but that PR also had issues with it.~~ Moving to #670 (Namely older versions of the software created the printer role, and the patch in #394 no longer creates it in database/migrations/2019_10_13_130718_create_roles_table.php, but these roles stay in the database if a database was created with an earlier version.)