### PR TITLE
Fix lp command for one-sided printing

### DIFF
--- a/app/Http/Controllers/Dormitory/Printing/PrintJobController.php
+++ b/app/Http/Controllers/Dormitory/Printing/PrintJobController.php
@@ -121,7 +121,11 @@ class PrintJobController extends Controller
             Log::error("Error while creating print job: " . $e->getMessage());
             return back()->with('error', __('print.error_printing'));
         } finally {
-            Storage::disk('printing')->delete($path);
+            /*
+             * Let's keep around the documents for easier troubleshooting
+             * TODO: clean up after an interval (e.g. 7 days)
+             */
+            // Storage::disk('printing')->delete($path);
         }
 
         DB::commit();

--- a/app/Models/Printer.php
+++ b/app/Models/Printer.php
@@ -87,9 +87,9 @@ class Printer extends Model
                 'lp',
                 '-h', "$this->ip:$this->port",
                 '-d', $this->name,
-                ($twoSided ? '-o sides=two-sided-long-edge' : ''),
-                 '-n', $copies,
-                 $path
+                '-o', ($twoSided ? 'sides=two-sided-long-edge' : 'sides=one-sided'),
+                '-n', $copies,
+                $path
             ]);
             $process->run();
             if (!$process->isSuccessful()) {


### PR DESCRIPTION
We were including an empty string in the arguments of `lp` when
performing one-sided printing. This was interpreted as an additional
file to be printed at path "". Also, this API leaves argument splitting
to us; how did it even work with `-o` and `sides=two-sided-long-edge`
being parsed as a single argument?