### PR TITLE
Use CLI for semester finalization instead of periodic events

### DIFF
--- a/app/Console/Commands/FinalizeSemesterEvaluation.php
+++ b/app/Console/Commands/FinalizeSemesterEvaluation.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Http\Controllers\Secretariat\SemesterEvaluationController;
+use Illuminate\Support\Facades\App;
+use App\Models\Semester;
+
+class FinalizeSemesterEvaluation extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:finalize-semester-evaluation {year} {part}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Finalizes the semester evaluation, deactivates collegists who has not set their new status.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $year = $this->argument('year');
+        $part = $this->argument('part');
+
+        
+        $semester = Semester::where('year', $year)->where('part', $part)->first();
+
+        App::setLocale('hu');
+        app(SemesterEvaluationController::class)->finalize($semester);
+    }
+}

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -43,7 +43,7 @@ class StatusTest extends TestCase
         $user = User::factory()->create(['verified' => true]);
         $user->setCollegist(Role::RESIDENT);
 
-        app(SemesterEvaluationController::class)->handlePeriodicEventEnd();
+        app(SemesterEvaluationController::class)->finalize(Semester::current());
 
         $this->assertFalse($user->hasRole(Role::COLLEGIST));
         $this->assertTrue($user->hasRole(Role::ALUMNI));


### PR DESCRIPTION
## Description
Szemeszter értékelés should be finalized similarly through CLI like how the admission process is finalized. This PR is in line with the requests of the Választmány.
## Related Issue
Closes #680
## Changes
- Removed automatic deactivation of collegists in the end of Semester evaluation
- Added command for deactivation of collegists for Semester evaluation