### PR TITLE
Added senior role and fixed problems with end-of-semester form

### DIFF
--- a/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
+++ b/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
@@ -137,7 +137,6 @@ class SemesterEvaluationController extends Controller
         $this->authorize('fillOrManage', SemesterEvaluation::class);
 
         return view('secretariat.evaluation-form.app', [
-            'phd' => user()->educationalInformation->isSenior(),
             'user' => user(),
             'faculties' => Faculty::all(),
             'workshops' => Workshop::all(),

--- a/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
+++ b/app/Http/Controllers/Secretariat/SemesterEvaluationController.php
@@ -245,9 +245,15 @@ class SemesterEvaluationController extends Controller
      */
     public function usersHaventFilledOutTheForm()
     {
-        return User::withRole(Role::COLLEGIST)->verified()->whereDoesntHave('semesterStatuses', function ($query) {
-            $query->where('semester_id', $this->semester()?->succ()?->id);
-        })->get();
+        return User::withRole(Role::COLLEGIST)
+            ->whereDoesntHave('roles', function ($query) {
+                $query->where('name', Role::SENIOR);
+            })
+            ->verified()
+            ->whereDoesntHave('semesterStatuses', function ($query) {
+                $query->where('semester_id', $this->semester()?->succ()?->id);
+            })
+            ->get();
     }
 
     /**

--- a/app/Models/EducationalInformation.php
+++ b/app/Models/EducationalInformation.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 use App\Models\Semester;
+use App\Models\Role;
 
 /**
  * Either B2 or C1.
@@ -113,11 +114,11 @@ class EducationalInformation extends Model
     }
 
     /**
-     * Whether the user is a senior (i.e. currently has a PhD study line).
+     * Whether the user is a senior
      */
     public function isSenior(): bool
     {
-        return $this->studyLines()->currentlyEnrolled()->where('type', 'phd')->exists();
+        return $this->user->isSenior();
     }
 
     /**

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -51,6 +51,7 @@ class Role extends Model
     public const ETHICS_COMMISSIONER = 'ethics-commissioner';
     public const ALUMNI = 'alumni';
     public const RECEPTIONIST = 'receptionist';
+    public const SENIOR = 'senior';
 
     //Students' Committe role's objects
     public const PRESIDENT = 'president';
@@ -125,7 +126,8 @@ class Role extends Model
         self::BOARD_OF_TRUSTEES_MEMBER,
         self::ETHICS_COMMISSIONER,
         self::ALUMNI,
-        self::RECEPTIONIST
+        self::RECEPTIONIST,
+        self::SENIOR
     ];
 
     protected $fillable = [

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -112,6 +112,7 @@ class Role extends Model
     public const ALL = [
         self::SYS_ADMIN,
         self::COLLEGIST,
+        self::SENIOR,
         self::TENANT,
         self::WORKSHOP_ADMINISTRATOR,
         self::WORKSHOP_LEADER,
@@ -126,8 +127,7 @@ class Role extends Model
         self::BOARD_OF_TRUSTEES_MEMBER,
         self::ETHICS_COMMISSIONER,
         self::ALUMNI,
-        self::RECEPTIONIST,
-        self::SENIOR
+        self::RECEPTIONIST
     ];
 
     protected $fillable = [
@@ -313,6 +313,7 @@ class Role extends Model
             self::ETHICS_COMMISSIONER => 'green lighten-2',
             self::ALUMNI => 'grey darken-1',
             self::RECEPTIONIST => 'brown',
+            self::SENIOR => 'teal', 
             default => 'grey',
         };
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -495,6 +495,10 @@ class User extends Authenticatable implements HasLocalePreference
         return $query->where('users.verified', 1);
     }
 
+    public function isSenior(): bool {
+        return $this->hasRole(Role::SENIOR);
+    }
+
     /**
      * Scope a query to only include users whose data can be accessed by the given user.
      * @param Builder $query

--- a/app/Policies/SemesterEvaluationPolicy.php
+++ b/app/Policies/SemesterEvaluationPolicy.php
@@ -20,7 +20,7 @@ class SemesterEvaluationPolicy
      */
     public function fill(User $user): Response|bool
     {
-        if(!$user->isCollegist(alumni: false)) {
+        if(!$user->isCollegist(alumni: false) || $user->hasRole(Role::SENIOR)) {
             return false;
         }
         if(!app(SemesterEvaluationController::class)->isActive()) {

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -139,7 +139,7 @@ class UserPolicy
             return $user->hasRole([Role::STAFF]);
         }
 
-        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI) {
+        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI || $role->name == Role::SENIOR) {
             return $user->hasRole([Role::SECRETARY, Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS]);
         }
 
@@ -203,7 +203,7 @@ class UserPolicy
             return $user->hasRole([Role::STAFF]);
         }
 
-        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI) {
+        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI || $role->name == Role::SENIOR) {
             return $user->hasRole([Role::SECRETARY, Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS]);
         }
 

--- a/database/migrations/2025_01_07_104622_add_senior_role.php
+++ b/database/migrations/2025_01_07_104622_add_senior_role.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('roles')->insert([
+            'name' => 'senior'
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('roles')->where('name', 'senior')->delete();
+    }
+};

--- a/resources/lang/en/role.php
+++ b/resources/lang/en/role.php
@@ -45,6 +45,7 @@ return [
     'roles' => 'Roles',
     'science-vice-president' => 'Scientific vice president',
     'secretary' => 'Secretary',
+    'senior' => 'Senior',
     'sp' => 'Spanish',
     'sport-committee' => 'Sport Committee',
     'sport-leader' => 'Sport committee leader',

--- a/resources/lang/hu/role.php
+++ b/resources/lang/hu/role.php
@@ -45,6 +45,7 @@ return [
     'roles' => 'Jogosultságok',
     'science-vice-president' => 'Szakmai alelnök',
     'secretary' => 'Titkárság',
+    'senior' => 'Senior',
     'sp' => 'Spanyol',
     'sport-committee' => 'Sportbizottság',
     'sport-leader' => 'Sportbizottsági elnök',

--- a/resources/views/emails/evaluation_form_available.blade.php
+++ b/resources/views/emails/evaluation_form_available.blade.php
@@ -1,8 +1,12 @@
 @component('mail::message')
     <h1>@lang('mail.dear') Collegisták!</h1>
     <p>
-        Töltsd ki a szemeszter végi kérdőívet, mely alapján a Tanári Kar értékelni tudja a félévedet. A kérdőív
-        kitöltése minden collegista számára kötelező.
+    A szemeszter végi értékelő form elérhetővé vált a Collegium BA/BSc, MA/MSc, osztatlan szakos hallgatói számára számára.
+    Töltsd ki a szemeszter végi kérdőívet, mely alapján a Tanári Kar értékelni tudja a félévedet.
+    A kérdőív kitöltése minden nem senior collegista számára kötelező.
+    </p>
+    <p>
+    A kérdőív senior hallgatók számára nem elérhető, a seniori beszámoló ettől függetlenül kerül lebonyolításra.
     </p>
     @component('mail::button', ['url' => route('secretariat.evaluation.show')])
         Kitöltés

--- a/resources/views/emails/evaluation_form_available_details.blade.php
+++ b/resources/views/emails/evaluation_form_available_details.blade.php
@@ -1,15 +1,17 @@
 @component('mail::message')
     <h1>@lang('mail.dear') {{ $recipient }}!</h1>
     <p>
-        A szemeszter végi értékelő form elérhetővé vált a collegisták számára.
+        A szemeszter végi értékelő form elérhetővé vált a Collegium BA/BSc, MA/MSc, osztatlan szakos hallgatói számára számára.
     </p>
     <p>
         A jelenlegi határideje: {{ $deadline }}. A határidő módosítható a rendszergazdák segítségével.
     </p>
     <p>
-        A kérdőív kitöltése kötelező, ellenkező esetben a rendszer automatikusan alumnivá állítja a collegistákat.<br/>
-        A státusz nyilvántartása miatt a (rövidített) kérdőív a seniorok számára is kötelezően kitöltendő, a seniori
-        beszámoló mellett.
+        A kérdőív kitöltése kötelező, ellenkező esetben a rendszer automatikusan alumnivá állítja a collegistákat.
+    </p>
+    <p>
+        A kérdőív senior hallgatók számára nem elérhető, a seniori beszámoló ettől függetlenül kerül lebonyolításra.
+        A seniori beszámolók alapján a seniorok státuszának beállítását manuálisan kell elvégezni.
     </p>
     <p>
         A kérdőív eredményei letölthetőek a <a href="{{ route('users.index') }}">@lang("general.users")</a> menüpont

--- a/resources/views/emails/evaluation_form_reminder.blade.php
+++ b/resources/views/emails/evaluation_form_reminder.blade.php
@@ -7,6 +7,9 @@
         Még {{ $count }} collegista nem töltötte ki a kérdőívet.
         A kérdőív segítségével tudja a Tanári Kar értékelni a félévet, így kitöltése kötelező.
     </p>
+    <p>
+        A kérdőív senior hallgatók számára nem elérhető, a seniori beszámoló ettől függetlenül kerül lebonyolításra.
+    </p>
     @component('mail::button', ['url' => route('secretariat.evaluation.show')])
         Kitöltés
     @endcomponent

--- a/resources/views/secretariat/evaluation-form/app.blade.php
+++ b/resources/views/secretariat/evaluation-form/app.blade.php
@@ -53,54 +53,52 @@
             </div>
         </div>
     </div>
-    @if(!$phd)
-        <div class="row">
-            <div class="col s12">
-                <div class="card" id="alfonso">
-                    <div class="card-content">
-                        <div class="card-title">Alfonsó</div>
-                        @include('user.alfonso-language-exams', ['user' => $user])
-                        <div class="row">
-                            <div class="col">
-                                <div class="divider" style="margin:10px"></div>
-                            </div>
+    <div class="row">
+        <div class="col s12">
+            <div class="card" id="alfonso">
+                <div class="card-content">
+                    <div class="card-title">Alfonsó</div>
+                    @include('user.alfonso-language-exams', ['user' => $user])
+                    <div class="row">
+                        <div class="col">
+                            <div class="divider" style="margin:10px"></div>
                         </div>
-                        @include('user.alfonso', ['user' => $user])
-                        @include('user.alfonso-requirements', ['user' => $user, 'evaluation' => true])
-                        <form method="POST" action="">
-                            @csrf
-                            <div class="row">
-                                <input type="hidden" name="section" value="alfonso"/>
-                                <x-input.text l=10 id="alfonso_note" :value="$evaluation?->alfonso_note"
-                                              text="Megjegyzés, helyesbítés, egyéni elbírálás"/>
-                                <x-input.button l=2 class="right" text="general.save"/>
-                            </div>
-                        </form>
                     </div>
+                    @include('user.alfonso', ['user' => $user])
+                    @include('user.alfonso-requirements', ['user' => $user, 'evaluation' => true])
+                    <form method="POST" action="">
+                        @csrf
+                        <div class="row">
+                            <input type="hidden" name="section" value="alfonso"/>
+                            <x-input.text l=10 id="alfonso_note" :value="$evaluation?->alfonso_note"
+                                            text="Megjegyzés, helyesbítés, egyéni elbírálás"/>
+                            <x-input.button l=2 class="right" text="general.save"/>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="col s12">
-                <div class="card" id="courses">
-                    <div class="card-content">
-                        <div class="card-title">EC-s kurzusok ({{\App\Models\Semester::current()->tag}})</div>
-                        @include('secretariat.evaluation-form.courses')
-                    </div>
+    </div>
+    <div class="row">
+        <div class="col s12">
+            <div class="card" id="courses">
+                <div class="card-content">
+                    <div class="card-title">EC-s kurzusok ({{\App\Models\Semester::current()->tag}})</div>
+                    @include('secretariat.evaluation-form.courses')
                 </div>
             </div>
         </div>
-        <div class="row">
-            <div class="col s12">
-                <div class="card" id="avg">
-                    <div class="card-content">
-                        <div class="card-title">Átlag</div>
-                        @include('secretariat.evaluation-form.avg')
-                    </div>
+    </div>
+    <div class="row">
+        <div class="col s12">
+            <div class="card" id="avg">
+                <div class="card-content">
+                    <div class="card-title">Átlag</div>
+                    @include('secretariat.evaluation-form.avg')
                 </div>
             </div>
         </div>
-    @endif
+    </div>
     <div class="row">
         <div class="col s12">
             <div class="card" id="general_assembly">


### PR DESCRIPTION
## Description
There have been multiple issues because mars did not have a registry of who is a senior. Especially in the case of the end-of-semester form as they are governed by a completely seperate ruleset as other collegists.
## Related Issue
Closes #660
## Changes
- Created senior role
- Seniors cannot and do not have to fill out the end-of-semester form
- Fixed email texts that seniors do NOT have to fill out the end-of-semester form and their report is not part of mars currently