### PR TITLE
Allow changes for Alumni role by the secretary and council leaders

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -139,7 +139,7 @@ class UserPolicy
             return $user->hasRole([Role::STAFF]);
         }
 
-        if ($role->name == Role::COLLEGIST) {
+        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI) {
             return $user->hasRole([Role::SECRETARY, Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS]);
         }
 
@@ -203,7 +203,7 @@ class UserPolicy
             return $user->hasRole([Role::STAFF]);
         }
 
-        if ($role->name == Role::COLLEGIST) {
+        if ($role->name == Role::COLLEGIST || $role->name == Role::ALUMNI) {
             return $user->hasRole([Role::SECRETARY, Role::STUDENT_COUNCIL => Role::STUDENT_COUNCIL_LEADERS]);
         }
 


### PR DESCRIPTION
## Description
Allow changes for Alumni role by the secretary and student council leaders
## Related Issue
Closes #665
## Changes
- Changing Alumni role is now the same as changing someones Collegist role (previously only sysadmins could edit, now secretary and counsil leaders can do it)