### PR TITLE
Remove unused Vue dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,7 @@
                 "popper.js": "^1.12",
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.27.0",
-                "sass-loader": "^13.2.2",
-                "vue": "^2.6.12",
-                "vue-template-compiler": "^2.6.12"
+                "sass-loader": "^13.2.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2224,17 +2222,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@vue/compiler-sfc": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
-            "integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
-            }
-        },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.12.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -3800,18 +3787,6 @@
             "engines": {
                 "node": ">=8.0.0"
             }
-        },
-        "node_modules/csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
-        },
-        "node_modules/de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-            "dev": true
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -8686,16 +8661,6 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
         },
-        "node_modules/vue": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
-            "integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
-            "dev": true,
-            "dependencies": {
-                "@vue/compiler-sfc": "2.7.13",
-                "csstype": "^3.1.0"
-            }
-        },
         "node_modules/vue-style-loader": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -8730,16 +8695,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/vue-template-compiler": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
-            "integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
-            "dev": true,
-            "dependencies": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
             }
         },
         "node_modules/watchpack": {
@@ -10926,17 +10881,6 @@
                 "@types/node": "*"
             }
         },
-        "@vue/compiler-sfc": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
-            "integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
-            "dev": true,
-            "requires": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
-            }
-        },
         "@webassemblyjs/ast": {
             "version": "1.12.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -12182,18 +12126,6 @@
             "requires": {
                 "css-tree": "^1.1.2"
             }
-        },
-        "csstype": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-            "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-            "dev": true
-        },
-        "de-indent": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-            "dev": true
         },
         "debug": {
             "version": "4.3.4",
@@ -15779,16 +15711,6 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
             "dev": true
         },
-        "vue": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
-            "integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
-            "dev": true,
-            "requires": {
-                "@vue/compiler-sfc": "2.7.13",
-                "csstype": "^3.1.0"
-            }
-        },
         "vue-style-loader": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
@@ -15819,16 +15741,6 @@
                         "json5": "^1.0.1"
                     }
                 }
-            }
-        },
-        "vue-template-compiler": {
-            "version": "2.7.13",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
-            "integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
-            "dev": true,
-            "requires": {
-                "de-indent": "^1.0.2",
-                "he": "^1.2.0"
             }
         },
         "watchpack": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
         "popper.js": "^1.12",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.27.0",
-        "sass-loader": "^13.2.2",
-        "vue": "^2.6.12",
-        "vue-template-compiler": "^2.6.12"
+        "sass-loader": "^13.2.2"
     },
     "dependencies": {
         "@materializecss/materialize": "^1.1.0",


### PR DESCRIPTION
`vue-template-compiler` has been flagged by Dependabot as vulnerable to XSS. This made me realize that this dependency is not used for anything, so let's yeet it.
