### PR TITLE
Prettifying arrow buttons for ranking questions

### DIFF
--- a/resources/views/utils/questions/ranking.blade.php
+++ b/resources/views/utils/questions/ranking.blade.php
@@ -5,13 +5,15 @@
 <ul id="{{ 'abstention-' . $question->formKey() }}" class="collection rcv-list rcv-abstention">
     @foreach($question->options()->get() as $option)
     <li class="collection-item row" data-id="{{ $option->id }}">
-        <div class="col s9">
+        <div class="col s8 m10" style="padding: 10px 0">
             <span style="display: inline-block; width: 1.5em" class="rcv-idx"></span>
             {{ $option->title }}
         </div>
-        <div class="col s3">
-            <button type="button" class="rcv-list-up"><i class="material-icons">keyboard_arrow_up</i></button>
-            <button type="button" class="rcv-list-down"><i class="material-icons">keyboard_arrow_down</i></button>
+        <div class="col s2 m1">
+            <button type="button" class="rcv-list-up btn-floating waves-effect waves-light right"><i class="material-icons">keyboard_arrow_up</i></button>
+        </div>
+        <div class="col s2 m1">
+            <button type="button" class="rcv-list-down btn-floating waves-effect waves-light right"><i class="material-icons">keyboard_arrow_down</i></button>
         </div>
     </li>
     @endforeach


### PR DESCRIPTION
As in the title. Look:

![grafik](https://github.com/user-attachments/assets/7365e9aa-4196-4ad9-b105-5f6ba501daca)

![grafik](https://github.com/user-attachments/assets/6329e9e4-7f8d-4181-b7bb-d989f8b4a86f)
