### PR TITLE
Allow users to opt out of Mr and Miss participation

### DIFF
--- a/app/Http/Controllers/StudentsCouncil/MrAndMissController.php
+++ b/app/Http/Controllers/StudentsCouncil/MrAndMissController.php
@@ -7,9 +7,11 @@ use App\Models\MrAndMissCategory;
 use App\Models\MrAndMissVote;
 use App\Models\Semester;
 use App\Models\User;
+use App\Models\MrAndMissOptOut;
 use App\Utils\HasPeriodicEvent;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -19,12 +21,12 @@ class MrAndMissController extends Controller
     use HasPeriodicEvent;
 
     /**
-     * Show the page for voting.
+     * Show the page for voting and opting out.
      * Accessible by collegists.
      */
     public function index(Request $request)
     {
-        $this->authorize('voteOrManage', MrAndMissVote::class);
+        $this->authorize('accessOrManage', MrAndMissVote::class);
 
         $categories = MrAndMissCategory::select(['mr_and_miss_categories.id', 'title', 'mr', 'custom', 'votee_id', 'votee_name as custom_name'])
             ->where('hidden', false)
@@ -46,9 +48,11 @@ class MrAndMissController extends Controller
             'student-council.mr-and-miss.index',
             [
                 'categories' => $categories,
-                'users' => User::collegists(),
+                'users' => $this->participatingUsers(),
                 'miss_first' => rand(0, 1) == 0,
                 'deadline' => $this->getDeadline(),
+                'start_date' => $this->getStartDate(),
+                'opted_out' => $this->optedOut(user()),
             ]
         );
     }
@@ -149,7 +153,7 @@ class MrAndMissController extends Controller
     {
         $this->authorize('manage', MrAndMissVote::class);
 
-        if(!$this->semester()) {
+        if (!$this->semester()) {
             throw new \Exception('Nincs megjeleníthető eredmény.');
         }
         $results = MrAndMissVote::select(DB::raw('count(*) as count, users.name, votee_name, title, mr, custom'))
@@ -230,5 +234,60 @@ class MrAndMissController extends Controller
         return redirect()->back()
             ->with('activate_custom', 'true') //go to the custom category page
             ->with('message', __('general.successful_modification'));
+    }
+
+    /*
+     * Opt out of participating.
+     * Accessible by collegists in the week leading up to the voting period.
+     */
+    public function optOut(Request $request)
+    {
+        $this->authorize('optOut', MrAndMissVote::class);
+
+        $validatedData = $request->validate([
+            'opt_out' => 'required|boolean',
+        ]);
+
+        if ($validatedData['opt_out']) {
+            MrAndMissOptOut::updateOrCreate([
+                'user_id' => user()->id,
+                'semester_id' => $this->semester()->id,
+            ]);
+        } else {
+            MrAndMissOptOut::where([
+                'user_id' => user()->id,
+                'semester_id' => $this->semester()->id,
+            ])->delete();
+        }
+
+        return back()->with('message', __('general.successful_modification'));
+    }
+
+    public function isOptOutPeriod(): bool
+    {
+        $startDate = $this->periodicEvent()?->startDate();
+
+        return $startDate && $startDate->between(Carbon::now(), Carbon::now()->addDays(7));
+    }
+
+    public function optedOut(User $user): bool
+    {
+        return MrAndMissOptOut::where([
+            'user_id' => $user->id,
+            'semester_id' => $this->semester()?->id,
+        ])->exists();
+    }
+
+    private function participatingUsers(): Collection
+    {
+        if (!$this->semester()) {
+            return new Collection();
+        }
+
+        return User::collegist()->active()->whereNotIn('id', function ($query) {
+            $query->select('user_id')
+                ->from('mr_and_miss_opt_outs')
+                ->where('semester_id', $this->semester()->id);
+        })->get();
     }
 }

--- a/app/Models/MrAndMissOptOut.php
+++ b/app/Models/MrAndMissOptOut.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * App\Models\MrAndMissOptOut
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property int $semester_id
+ * @method static \Illuminate\Database\Eloquent\Builder|MrAndMissOptOut newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|MrAndMissOptOut newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|MrAndMissOptOut query()
+ * @method static \Illuminate\Database\Eloquent\Builder|MrAndMissOptOut whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|MrAndMissOptOut whereSemesterId($value)
+ * @mixin \Eloquent
+ */
+class MrAndMissOptOut extends Model
+{
+    protected $fillable = ['user_id', 'semester_id'];
+}

--- a/app/Policies/MrAndMissVotePolicy.php
+++ b/app/Policies/MrAndMissVotePolicy.php
@@ -26,7 +26,7 @@ class MrAndMissVotePolicy
         if (!($user->isCollegist(alumni: false))) {
             return Response::deny('Csak collegisták szavazhatnak.');
         }
-        if(!app(MrAndMissController::class)->isActive()) {
+        if (!app(MrAndMissController::class)->isActive()) {
             return Response::deny('A szavazás jelenleg nem elérhető.');
         }
         return Response::allow();
@@ -40,9 +40,8 @@ class MrAndMissVotePolicy
      */
     public function manage(User $user): bool
     {
-        return $user->hasRole([Role::STUDENT_COUNCIL => Role::COMMUNITY_LEADER]);
+        return $user->isAdmin() || $user->hasRole([Role::STUDENT_COUNCIL => Role::COMMUNITY_LEADER]);
     }
-
 
     /**
      * Determine whether the user can vote or manage the categories and see the results.
@@ -52,7 +51,7 @@ class MrAndMissVotePolicy
      */
     public function voteOrManage(User $user)
     {
-        if(!$this->manage($user)) {
+        if (!$this->manage($user)) {
             return $this->vote($user);
         }
         return true;

--- a/app/Policies/MrAndMissVotePolicy.php
+++ b/app/Policies/MrAndMissVotePolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Http\Controllers\StudentsCouncil\MrAndMissController;
 use App\Models\User;
 use App\Models\Role;
+use App\Models\MrAndMissOptOut;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
 
@@ -15,13 +16,36 @@ class MrAndMissVotePolicy
 {
     use HandlesAuthorization;
 
+    /*
+     * Determine whether the Mr and Miss landing page should be accessible to the user.
+     */
+    public function access(User $user): Response
+    {
+        if (app(MrAndMissController::class)->isOptOutPeriod()) {
+            return $this->optOut($user);
+        }
+
+        return $this->vote($user);
+    }
+
+    /**
+    * Determine whether the user can opt out.
+    */
+    public function optOut(User $user): Response
+    {
+        if (!($user->isCollegist(alumni: false))) {
+            return Response::deny('Csak collegisták vehetnek részt.');
+        }
+        if (!app(MrAndMissController::class)->isOptOutPeriod()) {
+            return Response::deny('Jelenleg nem tudsz a Mr. és Missben való részvételről nyilatkozni.');
+        }
+        return Response::allow();
+    }
+
     /**
      * Determine whether the user can vote.
-     *
-     * @param User $user
-     * @return Response
      */
-    public function vote(User $user)
+    public function vote(User $user): Response
     {
         if (!($user->isCollegist(alumni: false))) {
             return Response::deny('Csak collegisták szavazhatnak.');
@@ -29,14 +53,14 @@ class MrAndMissVotePolicy
         if (!app(MrAndMissController::class)->isActive()) {
             return Response::deny('A szavazás jelenleg nem elérhető.');
         }
+        if (app(MrAndMissController::class)->optedOut($user)) {
+            return Response::deny('Lemondtál a szavazásban való részvételről.');
+        }
         return Response::allow();
     }
 
     /**
      * Determine whether the user can manage the categories and see the results.
-     *
-     * @param User $user
-     * @return bool
      */
     public function manage(User $user): bool
     {
@@ -44,15 +68,12 @@ class MrAndMissVotePolicy
     }
 
     /**
-     * Determine whether the user can vote or manage the categories and see the results.
-     *
-     * @param User $user
-     * @return bool|Response
+     * Determine whether the user can manage the vote, or participate/opt out.
      */
-    public function voteOrManage(User $user)
+    public function accessOrManage(User $user): Response|bool
     {
         if (!$this->manage($user)) {
-            return $this->vote($user);
+            return $this->access($user);
         }
         return true;
     }

--- a/database/migrations/2025_04_21_112234_add_mr_and_miss_opt_out.php
+++ b/database/migrations/2025_04_21_112234_add_mr_and_miss_opt_out.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('mr_and_miss_opt_outs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedSmallInteger('semester_id');
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('semester_id')->references('id')->on('semesters');
+            $table->unique(['user_id', 'semester_id']);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('mr_and_miss_opt_outs');
+    }
+};

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -121,7 +121,7 @@
                                         </a>
                                     </li>
                                     <!-- community committee -->
-                                    @can('voteOrManage', \App\Models\MrAndMissVote::class)
+                                    @can('accessOrManage', \App\Models\MrAndMissVote::class)
                                         <li>
                                             <a class="waves-effect" href="{{ route('mr_and_miss.index') }}">
                                                 <i class="material-icons left">how_to_vote</i> Mr. és Miss Eötvös

--- a/resources/views/student-council/mr-and-miss/index.blade.php
+++ b/resources/views/student-council/mr-and-miss/index.blade.php
@@ -11,7 +11,6 @@
 
 @section('content')
     <div class="row">
-
         <div class="col s12">
             @can('manage', \App\Models\MrAndMissVote::class)
                 <p>
@@ -19,11 +18,38 @@
                     <x-input.button :href="route('mr_and_miss.results')" text="Eredmények" />
                 </p>
             @endcan
+            @can('optOut', \App\Models\MrAndMissVote::class)
+            <div class="card">
+                <div class="card-content">
+                    <span class="card-title">Mr. és Miss Eötvös részvétel</span>
+                    <p>
+                        Amennyiben nem szeretnél részt venni az idei Mr. és Miss Eötvösben, a szavazási időszak kezdetéig <span>({{ $start_date }})</span> a lenti gombbal jelezheted.
+                        Ekkor mások nem adhatnak le rád szavazatot, és te sem tudsz szavazni.
+                    </p>
+                </div>
+                <div class="card-action right-align">
+                    <form action="{{ route('mr_and_miss.opt_out') }}" method="post">
+                        <input type="hidden" name="opt_out" value="{{ $opted_out ? '0' : '1' }}">
+                        @csrf
+                        @if ($opted_out)
+                            <button class="btn waves-effect waves-light green" type="submit">Részt veszek
+                                <i class="material-icons right">check</i>
+                            </button>
+                        @else
+                            <button class="btn waves-effect waves-light red" type="submit">Nem szeretnék részt venni
+                                <i class="material-icons right">clear</i>
+                            </button>
+                        @endif
+                    </form>
+                </div>
+            </div>
+            @elsecan('vote', \App\Models\MrAndMissVote::class)
             <div class="card">
                 <div class="card-content">
                     <span class="card-title">Szavazás</span>
                     <p>
-                        Külön tudtok szavazni a Mr, a Miss, illetve az egyéni kategóriákban. Lehetőleg a keresők segítségével válasszátok ki a jelölteteket, azonban ha nem találjátok az illetőt a rendszerben, a sor végén található gombbal tudtok szabad kezes bevitelre váltani.
+                        Külön tudtok szavazni a Mr, a Miss, illetve az egyéni kategóriákban. Lehetőleg a keresők segítségével válasszátok ki a jelölteteket.
+                        A listában azok az aktív collegisták szerepelnek, akik nem jelezték, hogy nem szeretnének részt venni a szavazásban. Ha a felsorolt lehetőségek helyett másra szavaznátok, a sor végén található gombbal szabad kezes bevitelre válthattok.
                         A határidőig bárhányszor módosíthatjátok a szavazatokat.
                     </p>
                     <blockquote>
@@ -34,7 +60,6 @@
                     @endforeach
                 </div>
             </div>
-            @can('vote', \App\Models\MrAndMissVote::class)
             <div class="card">
                 <div class="card-tabs">
                     <ul class="tabs tabs-fixed-width">

--- a/routes/web.php
+++ b/routes/web.php
@@ -251,6 +251,7 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
     Route::get('/community_committee/mr_and_miss', [MrAndMissController::class, 'index'])->name('mr_and_miss.index');
     Route::post('/community_committee/mr_and_miss/vote', [MrAndMissController::class, 'saveVote'])->name('mr_and_miss.vote.save');
     Route::post('/community_committee/mr_and_miss/vote/custom', [MrAndMissController::class, 'customVote'])->name('mr_and_miss.vote.custom');
+    Route::post('/community_committee/mr_and_miss/opt_out', [MrAndMissController::class, 'optOut'])->name('mr_and_miss.opt_out');
     Route::get('/community_committee/mr_and_miss/admin', [MrAndMissController::class, 'indexAdmin'])->name('mr_and_miss.admin');
     Route::post('/community_committee/mr_and_miss/admin/categories', [MrAndMissController::class, 'createCategory'])->name('mr_and_miss.categories.create');
     Route::post('/community_committee/mr_and_miss/admin/categories/create', [MrAndMissController::class, 'editCategories'])->name('mr_and_miss.categories.edit');


### PR DESCRIPTION
We show a simple button a week before the voting period's start where
users can declare that they do not want to participate. In that case,
they won't show up in the drop-down lists for other users, and they
themselves can't vote either.


