### PR TITLE
Added departure statement

### DIFF
--- a/app/Http/Controllers/Secretariat/DocumentController.php
+++ b/app/Http/Controllers/Secretariat/DocumentController.php
@@ -9,7 +9,6 @@ use App\Models\ImportItem;
 use App\Console\Commands;
 use App\Utils\Printer;
 use App\Http\Controllers\Controller;
-
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
@@ -40,6 +39,16 @@ class DocumentController extends Controller
         Gate::authorize('document.register-statement');
 
         $result = $this->generateRegisterStatement();
+        return $this->downloadDocument($result);
+    }
+
+    /** Departure statement */
+
+    public function downloadDepartureStatement()
+    {
+        Gate::authorize('document.departure-statement');
+
+        $result = $this->generateDepartureStatement();
         return $this->downloadDocument($result);
     }
 
@@ -165,7 +174,7 @@ class DocumentController extends Controller
         }
     }
 
-    private function generateRegisterStatement()
+    private function generateStatement($template_name)
     {
         $user = user();
 
@@ -178,7 +187,7 @@ class DocumentController extends Controller
         $info = $user->personalInformation;
 
         $pdf = $this->generatePDF(
-            'latex.register-statement',
+            $template_name,
             [ 'name' => $user->name,
               'address' => $info->zip_code . ' ' . $info->getAddress(),
               'phone' => $info->phone_number,
@@ -189,6 +198,16 @@ class DocumentController extends Controller
         ]
         );
         return ['success' => true, 'pdf' => $pdf];
+    }
+
+    private function generateRegisterStatement()
+    {
+        return $this->generateStatement('latex.register-statement');
+    }
+
+    private function generateDepartureStatement()
+    {
+        return $this->generateStatement('latex.departure-statement');
     }
 
     private function generateImport()

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -44,6 +44,10 @@ class AuthServiceProvider extends ServiceProvider
             return $user->isCollegist(alumni: false)
                 || $user->hasRole(Role::TENANT);
         });
+        Gate::define('document.departure-statement', function ($user) {
+            return $user->isCollegist(alumni: false)
+                || $user->hasRole(Role::TENANT);
+        });
         Gate::define('document.import-license', function ($user) {
             return $user->isCollegist()
                 || $user->hasRole(Role::TENANT);
@@ -54,6 +58,7 @@ class AuthServiceProvider extends ServiceProvider
                 'document.status-certificate.viewAny',
                 'document.status-certificate',
                 'document.register-statement',
+                'document.departure-statement',
                 'document.import-license',
             ]);
         });

--- a/resources/views/latex/departure-statement.blade.php
+++ b/resources/views/latex/departure-statement.blade.php
@@ -26,7 +26,7 @@
 \begin{document}
 
 \begin{center}
-\Large \textsc{Eötvös József Collegium \\ Beköltözési nyilatkozat} \\ \normalsize (Házirend, 1. sz. melléklet)
+\Large \textsc{Eötvös József Collegium \\ Kiköltözési nyilatkozat} \\ \normalsize (Házirend, 3. sz. melléklet)
 \end{center}
 
 \vspace*{2em}
@@ -37,25 +37,40 @@ Telefonszám: {{ \App\Utils\LatexSanitizer::sanitizeLatex($phone) }} \\
 E-mail: {{ \App\Utils\LatexSanitizer::sanitizeLatex($email) }} \\
 Születési hely és idő: {{ \App\Utils\LatexSanitizer::sanitizeLatex($place_and_of_birth) }} \\
 Anyja neve: {{ \App\Utils\LatexSanitizer::sanitizeLatex($mothers_name) }} \\
-Beköltözés dátuma: \\
+Kiköltözés dátuma: \\
 \\
-Megjegyzések:
-
-A szobában lévő berendezéseket csak gondnoki engedéllyel lehet cserélni. A behozatali engedélyt a beköltözési nyilatkozattal együtt kell leadni. A ki - és beköltözést, valamint az átköltözést minden esetben jelenteni kell a gondnoknak és a Választmánynak is.
-
-A beköltözéssel elfogadom a Házirendet, valamint az intézmény Munka-, tűz- és vagyonvédelmi
-előírásait.
-
-\vspace{4em}
-A fentieket tudomásul vettem, a szobát a leltár szerint átvettem.
+A szobát a leltár szerint átadtam.
 
 \vspace{2em}
 \noindent{}Budapest, {{ \App\Utils\LatexSanitizer::sanitizeLatex($date) }}
 
 \hfill\lotofdots
 
-\hfill aláírás\hspace{3.5em}
+\hfill Aláírás\hspace{3.5em}
 
 \vspace{3em}
+
+\hline
+
+\vspace{2em}
+
+\noindent{}A szobát ellenőriztük, állapota rendezett, kitakarított.\\
+Budapest, {{ \App\Utils\LatexSanitizer::sanitizeLatex($date) }}
+
+\vspace{3em}
+
+\hfill\lotofdots
+
+\hfill Aláírás\hspace{3.5em}
+
+\hfill Gondnokság\hspace{2em}
+
+\vspace{3em}
+
+\hfill\lotofdots
+
+\hfill Aláírás\hspace{3.5em}
+
+\hfill Választmányi delegált
 
 \end{document}

--- a/resources/views/secretariat/document/index.blade.php
+++ b/resources/views/secretariat/document/index.blade.php
@@ -28,6 +28,15 @@
                             </td>
                         </tr>
                         @endcan
+                        @can('document.departure-statement')
+                        <tr>
+                            <td>Kiköltözési nyilatkozat</td>
+                            <td></td>
+                            <td>
+                                <x-input.button :href="route('documents.departure-statement.download')" text="letöltés" />
+                            </td>
+                        </tr>
+                        @endcan
                         @can('document.import-license')
                         <tr>
                             <td>Behozatali engedély</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -215,6 +215,7 @@ Route::middleware([Authenticate::class, LogRequests::class, EnsureVerified::clas
     Route::get('/documents', [DocumentController::class, 'index'])->name('documents');
     Route::get('/documents/register-statement/download', [DocumentController::class, 'downloadRegisterStatement'])->name('documents.register-statement.download');
     Route::get('/documents/register-statement/print', [DocumentController::class, 'printRegisterStatement'])->name('documents.register-statement.print');
+    Route::get('/documents/departure-statement/download', [DocumentController::class, 'downloadDepartureStatement'])->name('documents.departure-statement.download');
     Route::get('/documents/import/show', [DocumentController::class, 'showImport'])->name('documents.import.show');
     Route::post('/documents/import/add', [DocumentController::class, 'addImport'])->name('documents.import.add');
     Route::post('/documents/import/remove', [DocumentController::class, 'removeImport'])->name('documents.import.remove');


### PR DESCRIPTION
The content of departure statements have changed this semester in the building's policy. Since it also makes the document longer, a seperate document type has been added.

The PR contains the following changes:
- Removed the elements for departure statement from the registration statement
- Added a template for departure statement in Latex
- Created the appropriate route and Controller changes for the new statement

I did not include direct printing functionality for the document (see \#689 and \#731 for additional context).