### PR TITLE
Fix reservations

### DIFF
--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -274,7 +274,7 @@ class Timetable extends Component
             $block = $blocks[$i];
 
             // this has to be modifiable
-            $splittingPointAfter = Carbon::make($block->getFrom());
+            $splittingPointAfter = Carbon::make(Carbon::createFromImmutable($block->getFrom()));
             if ($block->isFree()) {
                 $splittingPointAfter->minute = 0;
                 $splittingPointAfter->addHours(1);

--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -6,7 +6,6 @@ use Livewire\Component;
 use Livewire\Attributes\On;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-
 use App\Models\Reservations\ReservableItem;
 use App\Models\Reservations\Reservation;
 
@@ -218,7 +217,7 @@ class Timetable extends Component
 
         $currentStart = $from;
         $i = 0;
-        while($i < count($reservations)) {
+        while ($i < count($reservations)) {
             if ($isForReservation) {
                 $reservation = $reservations[$i];
                 $blocks[] = new Block(

--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -350,7 +350,9 @@ class Timetable extends Component
      */
     public function step(int $days): void
     {
+        $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay->addDays($days);
+        $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($days);
     }
 
@@ -362,7 +364,9 @@ class Timetable extends Component
     public function firstDayUpdated(string $firstDay): void
     {
         $oldFirstDay = $this->firstDay;
+        $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay = Carbon::make($firstDay);
+        $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($oldFirstDay->diffInDays($this->firstDay));
     }
 }


### PR DESCRIPTION
## Description
This PR fixes two issues with reservations. One causes misalignment, the other is due to incorrect timezones.
## Related Issue
Closes #722
## Additional Notes
Check the commits for additional context