### PR TITLE
Fix 653

### DIFF
--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -274,7 +274,7 @@ class Timetable extends Component
             $block = $blocks[$i];
 
             // this has to be modifiable
-            $splittingPointAfter = Carbon::make($block->getFrom());
+            $splittingPointAfter = Carbon::make(Carbon::createFromImmutable($block->getFrom()));
             if ($block->isFree()) {
                 $splittingPointAfter->minute = 0;
                 $splittingPointAfter->addHours(1);

--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -6,7 +6,6 @@ use Livewire\Component;
 use Livewire\Attributes\On;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-
 use App\Models\Reservations\ReservableItem;
 use App\Models\Reservations\Reservation;
 
@@ -219,7 +218,7 @@ class Timetable extends Component
 
         $currentStart = $from;
         $i = 0;
-        while($i < count($reservations)) {
+        while ($i < count($reservations)) {
             if ($isForReservation) {
                 $reservation = $reservations[$i];
                 $blocks[] = new Block(

--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -350,7 +350,9 @@ class Timetable extends Component
      */
     public function step(int $days): void
     {
+        $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay->addDays($days);
+        $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($days);
     }
 
@@ -362,7 +364,9 @@ class Timetable extends Component
     public function firstDayUpdated(string $firstDay): void
     {
         $oldFirstDay = $this->firstDay;
+        $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay = Carbon::make($firstDay);
+        $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($oldFirstDay->diffInDays($this->firstDay));
     }
 }

--- a/app/Livewire/Timetable.php
+++ b/app/Livewire/Timetable.php
@@ -148,6 +148,7 @@ class Timetable extends Component
      * The last day of the span displayed (inclusive).
      */
     public Carbon $lastDay;
+    public string $firstDayYYYYMMDD;
     /**
      * The first hour to be displayed in the table, inclusive (defaults to 0).
      */
@@ -326,6 +327,7 @@ class Timetable extends Component
         } else {
             $this->firstDay = Carbon::today();
         }
+        $this->firstDayYYYYMMDD = $this->firstDay->isoFormat('YYYY-MM-DD');
         $this->lastDay = $this->firstDay->copy()->addDays($days - 1);
 
         $this->firstHour = $firstHour;
@@ -352,6 +354,7 @@ class Timetable extends Component
     {
         $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay->addDays($days);
+        $this->firstDayYYYYMMDD = $this->firstDay->isoFormat('YYYY-MM-DD');
         $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($days);
     }
@@ -366,6 +369,7 @@ class Timetable extends Component
         $oldFirstDay = $this->firstDay;
         $this->firstDay->setTimezone(config('app.timezone'));
         $this->firstDay = Carbon::make($firstDay);
+        $this->firstDayYYYYMMDD = $this->firstDay->isoFormat('YYYY-MM-DD');
         $this->lastDay->setTimezone(config('app.timezone'));
         $this->lastDay->addDays($oldFirstDay->diffInDays($this->firstDay));
     }

--- a/resources/views/livewire/timetable.blade.php
+++ b/resources/views/livewire/timetable.blade.php
@@ -17,26 +17,26 @@ $absoluteHeight = $isPrintVersion ? '650px' : '1000px';
 
 @push('scripts')
 <script>
+
     document.addEventListener('DOMContentLoaded', function() {
-        var elem = document.getElementById('firstDay');
-        M.Datepicker.init(elem, {
-            format: 'yyyy-mm-dd',
-            firstDay: 1,
-            showClearBtn: false,
-            onClose: () => @this.firstDayUpdated(elem.value)
+        const firstDay = document.getElementById("firstDay");
+        firstDay.addEventListener('click', function(event) {
+            event.target.showPicker();
         });
+        firstDay.addEventListener('change', function(event) {
+            @this.firstDayUpdated(event.target.value);
+        });
+        setTimeout(function(){
+            firstDay.value = "{{$firstDayYYYYMMDD}}";
+        }, 50); //FIXME, it is a terrible hack
 
         window.stepDays = function(days) {
             @this.step(days);
-            const elem = document.getElementById('firstDay');
-            let date = new Date(elem.value);
-            date.setDate(date.getDate() + days);
-            // HACK: This is the easiest way to get yyyy-mm-dd.
-            elem.value = date.toISOString().slice(0, 10);
         };
     });
 </script>
 @endpush
+
 
 <div>
     {{-- navigation buttons --}}
@@ -51,10 +51,11 @@ $absoluteHeight = $isPrintVersion ? '650px' : '1000px';
         <div class="col s4 left-align">
             <x-input.button floating onclick="stepDays({{ -1 * $dayCount }})" icon="chevron_left" />
         </div>
-        <div class="col s4 center-align" wire:ignore>
-            <input type="text" class="datepicker validate" id="firstDay" value="{{$firstDay->format('Y-m-d')}}"
-                    style="color:#b38f2f; text-decoration: underline; border: none; box-shadow: none;
-                    text-align: center; font-size: 1.2em; cursor: pointer" >
+        <div class="col s4 center-align">
+        <input type="date" 
+            style="color:#b38f2f; text-decoration: underline; border: none; box-shadow: none;
+                    text-align: center; font-size: 1.2em; cursor: pointer"
+            id="firstDay" wire:model="firstDayYYYYMMDD">
         </div>
         <div class="col s4 right-align">
             <x-input.button floating onclick="stepDays({{ $dayCount }})" icon="chevron_right" />


### PR DESCRIPTION
The main problem is that using livewire with dates seems to be quite impractical.
Like: putting a simple text field `<input type="text" value="{{$firstDayYYYYMMDD}}">` works fine, but updating does not work (at all) if we navigate back to the page with dates on Chrome: `<input type="date" value="{{$firstDayYYYYMMDD}}">`
With `<input type="date" wire:model="firstDayYYYYMMDD">` and `<input type="text" wire:model="firstDayYYYYMMDD">` updating works even if we navigate back to the page but it shows the old date for the first time in Chrome.
I'm not an expert in Livewire and from all of my tried solutions, I could only get it to work by waiting for a bit and update the value of the input field.

I could not get it to work with materialize's datepicker on chrome, so the original HTML element is used.

I am quite unhappy with the quality of this change but at least it makes it functional.