### PR TITLE
Distinguish different document types for applications

### DIFF
--- a/app/Enums/FileType.php
+++ b/app/Enums/FileType.php
@@ -2,7 +2,7 @@
 
 namespace App\Enums;
 
-enum FileType : string
+enum FileType: string
 {
     case PROFILE_PICTURE = 'profile_picture';
     case RECEIPT = 'receipt';

--- a/app/Enums/FileType.php
+++ b/app/Enums/FileType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum FileType : string
+{
+    case PROFILE_PICTURE = 'profile_picture';
+    case RECEIPT = 'receipt';
+    case RESUME = 'resume';
+    case BESOROLASI_HATAROZAT = 'besorolasi_hatarozat';
+    case ERETTSEGI = 'erettsegi';
+    case ELVEGZETT_FELEV = 'elvegzett_felev';
+    case DIPLOMA = 'diploma';
+    case APPLICATION_CUSTOM = 'application_custom';
+}

--- a/app/Http/Controllers/ConfigurableText/ConfigurableTextController.php
+++ b/app/Http/Controllers/ConfigurableText/ConfigurableTextController.php
@@ -36,6 +36,16 @@ class ConfigurableTextController extends Controller
                 $text_fields[] = $configurable_text;
             }
         }
+        foreach (\App\Enums\FileType::cases() as $type) {
+            if ($type == \App\Enums\FileType::PROFILE_PICTURE || $type == \App\Enums\FileType::RECEIPT) {
+                continue; // Used internally, no user-visible description
+            }
+
+            $configurable_text = ConfigurableText::getConfigurableText("APPLICATION_FILE_" . strtoupper($type->value));
+            if (user()->can('edit', $configurable_text)) {
+                $text_fields[] = $configurable_text;
+            }
+        }
         return view(
             'configurable_texts.manage',
             [

--- a/app/Http/Controllers/Secretariat/UserController.php
+++ b/app/Http/Controllers/Secretariat/UserController.php
@@ -69,7 +69,7 @@ class UserController extends Controller
             $old_profile->update(['path' => $path]);
             Storage::delete($old_profile->path);
         } else {
-            $user->profilePicture()->create(['path' => $path, 'name' => 'profile_picture']);
+            $user->profilePicture()->create(['path' => $path, 'type' => 'profile_picture']);
         }
         return redirect()->back()->with('message', __('general.successful_modification'));
     }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Utils\DataCompresser;
+use App\Enums\FileType;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -171,6 +172,15 @@ class Application extends Model
         return $this->hasMany('App\Models\File');
     }
 
+    /**
+     * Get files of a specific type.
+     * @param FileType $type
+     * @return HasMany
+     */
+    public function filesOfType(FileType $type): HasMany
+    {
+        return $this->files()->where('type', $type);
+    }
 
     /*
     |--------------------------------------------------------------------------
@@ -414,6 +424,9 @@ class Application extends Model
         if (!isset($this->question_2)) {
             $missingData[] =  'Szakmai és motivációs kérdések: "Miért kíván a Collegium tagja lenni?" kérdés';
         }
+        if ($this->question_2 && mb_strlen($this->question_2) < 500) {
+            $missingData[] =  'Szakmai és motivációs kérdések: "Miért kíván a Collegium tagja lenni?" kérdésre adott válasz túl rövid (min. 500 leütés)';
+        }
         if (!isset($this->question_3)) {
             $missingData[] =  'Szakmai és motivációs kérdések: "Tervez-e tovább tanulni a diplomája megszerzése után? Milyen tervei vannak az egyetem után?" kérdés';
         }
@@ -422,11 +435,37 @@ class Application extends Model
             $missingData[] =  'Szakmai és motivációs kérdések: jelige';
         }
 
-        if (count($this->files) < 2) {
-            $missingData[] =  'Legalább két feltöltött fájl';
+        foreach (FileType::cases() as $type) {
+            if ($this->needsFile($type) && !$this->filesOfType($type)->exists()) {
+                $missingData[] = 'Szükséges dokumentum: ' . __('document.file_types.' . $type->value, [], 'hu');
+            }
         }
 
         return $missingData;
+    }
+
+    /**
+     * Determine whether the applicant needs to upload a file of a specific type.
+     * @param FileType $type
+     * @return bool
+     */
+    public function needsFile(FileType $type): bool
+    {
+        $semester = app(\App\Http\Controllers\Auth\ApplicationController::class)->semester();
+        switch ($type) {
+            case FileType::RESUME:
+                return true;
+            case FileType::BESOROLASI_HATAROZAT:
+                return $this->user->educationalInformation->studyLines()->where('start', '=', $semester->id)->exists();
+            case FileType::ERETTSEGI:
+                return $this->user->educationalInformation->studyLines()->where('start', '=', $semester->id)->whereIn('type', ['bachelor', 'ot', 'other'])->exists();
+            case FileType::ELVEGZETT_FELEV:
+                return $this->user->educationalInformation->studyLines()->where('start', '<>', $semester->id)->exists();
+            case FileType::DIPLOMA:
+                return $this->user->educationalInformation->studyLines()->whereNotNull('end')->exists();
+            default:
+                return false;
+        }
     }
 
     /**

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -2,30 +2,33 @@
 
 namespace App\Models;
 
+use App\Enums\FileType;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * App\Models\File
  *
  * @property int $id
- * @property int|null $application_form_id
+ * @property int|null $application_id
  * @property int|null $user_id
- * @property string $name
+ * @property int|null $transaction_id
+ * @property FileType|null $type
+ * @property string|null $description
  * @property string $path
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|File newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|File newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|File query()
- * @method static \Illuminate\Database\Eloquent\Builder|File whereApplicationFormId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|File whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|File whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|File whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|File wherePath($value)
- * @method static \Illuminate\Database\Eloquent\Builder|File whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File whereApplicationId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|File whereUserId($value)
- * @property int|null $transaction_id
  * @method static \Illuminate\Database\Eloquent\Builder|File whereTransactionId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File wherePath($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|File whereUpdatedAt($value)
  * @mixin \Eloquent
  */
 class File extends Model
@@ -33,9 +36,15 @@ class File extends Model
     protected $table = 'files';
 
     protected $fillable = [
+        'application_id',
         'user_id',
-        'application_id', //if belongs to an application
-        'name',
+        'transaction_id',
+        'type',
+        'description',
         'path',
+    ];
+
+    protected $casts = [
+        'type' => FileType::class,
     ];
 }

--- a/app/Utils/ApplicationHandler.php
+++ b/app/Utils/ApplicationHandler.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 
 trait ApplicationHandler
 {
@@ -73,9 +74,10 @@ trait ApplicationHandler
         $request->validate([
             'file' => 'required|file|mimes:pdf,jpg,jpeg,png|max:' . config('custom.general_file_size_limit'),
             'name' => 'required|string|max:255',
+            'type' => ['required', Rule::enum(\App\Enums\FileType::class)],
         ]);
         $path = $request->file('file')->store('uploads');
-        $user->application->files()->create(['path' => $path, 'name' => $request->input('name')]);
+        $user->application->files()->create(['path' => $path, 'type' => $request->input('type'), 'description' => $request->input('name')]);
     }
 
     /**

--- a/database/migrations/2025_07_23_011711_add_file_type.php
+++ b/database/migrations/2025_07_23_011711_add_file_type.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     private const FILE_TYPES = [
         'profile_picture',
         'receipt',

--- a/database/migrations/2025_07_23_011711_add_file_type.php
+++ b/database/migrations/2025_07_23_011711_add_file_type.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    private const FILE_TYPES = [
+        'profile_picture',
+        'receipt',
+        'resume',
+        'besorolasi_hatarozat',
+        'erettsegi',
+        'elvegzett_felev',
+        'diploma',
+        'application_custom'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('files', function (Blueprint $table) {
+            $table->enum('type', self::FILE_TYPES)->nullable(true)->after('user_id');
+            $table->string('name')->nullable()->change();
+        });
+
+        DB::statement("
+            UPDATE files
+            SET type = CASE
+            WHEN name = 'profile_picture' THEN 'profile_picture'
+            WHEN name = 'receipt' THEN 'receipt'
+            ELSE 'application_custom'
+            END
+        ");
+
+        DB::statement("
+            UPDATE files
+            SET name = NULL
+            WHERE type != 'application_custom'
+        ");
+
+        Schema::table('files', function (Blueprint $table) {
+            $table->enum('type', self::FILE_TYPES)->nullable(false)->change();
+            $table->renameColumn('name', 'description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("
+            UPDATE files
+            SET description = type
+            WHERE description IS NULL
+        ");
+
+        Schema::table('files', function (Blueprint $table) {
+            $table->dropColumn('type');
+            $table->renameColumn('description', 'name');
+            $table->string('name')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2025_07_23_013427_application_configurable_text.php
+++ b/database/migrations/2025_07_23_013427_application_configurable_text.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_07_23_013427_application_configurable_text.php
+++ b/database/migrations/2025_07_23_013427_application_configurable_text.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_RESUME',
+            'rawtext' => 'Hagyományos, leíró jellegű önéletrajz (**nem** Europass típusú). Feltétlenül térjen ki a szakmai motivációira, tanulmányi- és versenyeredményeire.',
+        ]);
+
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_BESOROLASI_HATAROZAT',
+            'rawtext' => 'A képzésre frissen felvételt nyert hallgatók esetén a Felvi *Hivatalos dokumentumok* menüpontjából letölthető besorolási határozatot kérjük feltölteni.
+
+Kérjük, figyeljen arra, hogy ne más, a felvételt igazoló dokumentumot (pl. felvételi határozat) töltsön fel!',
+        ]);
+
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_ERETTSEGI',
+            'rawtext' => 'Érettségi bizonyítványa, valamint érettségi tanúsítványai, ha rendelkezik ilyenekkel (az érettségi törzslapkivonatot **nem** szükséges feltöltenie).',
+        ]);
+
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_ELVEGZETT_FELEV',
+            'rawtext' => 'Igazolás minden eddig elvégzett egyetemi félévéről (pl. leckekönyv, törzslap-kivonat, diplomamelléklet stb.).',
+        ]);
+
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_DIPLOMA',
+            'rawtext' => 'Az összes korábban elvégzett egyetemi képzésének diplomája.',
+        ]);
+
+        \DB::table('configurable_texts')->insert([
+            'key' => 'APPLICATION_FILE_APPLICATION_CUSTOM',
+            'rawtext' => 'Ide tölthet fel minden olyan dokumentumot, igazolást, amelyet fontosnak tart a jelentkezésével kapcsolatban. Például: oklevelek, eredményekről szóló igazolások, tanári ajánlás.',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_RESUME')->delete();
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_BESOROLASI_HATAROZAT')->delete();
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_ERETTSEGI')->delete();
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_ELVEGZETT_FELEV')->delete();
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_DIPLOMA')->delete();
+        \DB::table('configurable_texts')->where('key', 'APPLICATION_FILE_APPLICATION_CUSTOM')->delete();
+    }
+};

--- a/resources/lang/en/configurable_texts.php
+++ b/resources/lang/en/configurable_texts.php
@@ -11,5 +11,11 @@ return [
         'APPLICATION_INFORMATION_PER_WORKSHOP_AFTER_FINALIZATION' => 'Information about workshops the user applied to',
         'START_APPLICATION' => 'Confirmation text before a user with an already existing account starts their application',
         'TENANT_REGISTRATION' => 'Texts shown on tenant registration page',
+        'APPLICATION_FILE_RESUME' => 'Description for "Önéletrajz" file type',
+        'APPLICATION_FILE_BESOROLASI_HATAROZAT' => 'Description for "Besorolási határozat" file type',
+        'APPLICATION_FILE_ERETTSEGI' => 'Description for "Érettségi" file type',
+        'APPLICATION_FILE_ELVEGZETT_FELEV' => 'Description for "Elvégzett félév" file type',
+        'APPLICATION_FILE_DIPLOMA' => 'Description for "Diploma" file type',
+        'APPLICATION_FILE_APPLICATION_CUSTOM' => 'Description for "Egyéb felvételi dokumentum, igazolás" file type',
     ],
 ];

--- a/resources/lang/hu/configurable_texts.php
+++ b/resources/lang/hu/configurable_texts.php
@@ -11,5 +11,11 @@ return [
         'APPLICATION_INFORMATION_PER_WORKSHOP_AFTER_FINALIZATION' => 'Információk a jelentkezőknek a véglegesítés után az adott műhelyről',
         'START_APPLICATION' => 'Jóváhagyás olyan felhasználóknak, akik korábban regisztráltak, de kezdeményezik a felvételijüket',
         'TENANT_REGISTRATION' => 'Vendégregisztrációkor megjelenő szövegek',
+        'APPLICATION_FILE_RESUME' => 'Önéletrajz fájltípus leírása',
+        'APPLICATION_FILE_BESOROLASI_HATAROZAT' => 'Besorolási határozat fájltípus leírása',
+        'APPLICATION_FILE_ERETTSEGI' => 'Érettségi fájltípus leírása',
+        'APPLICATION_FILE_ELVEGZETT_FELEV' => 'Elvégzett félév fájltípus leírása',
+        'APPLICATION_FILE_DIPLOMA' => 'Diploma fájltípus leírása',
+        'APPLICATION_FILE_APPLICATION_CUSTOM' => 'Egyéb felvételi dokumentum, igazolás fájltípus leírása',
     ],
 ];

--- a/resources/lang/hu/document.php
+++ b/resources/lang/hu/document.php
@@ -9,4 +9,14 @@ return [
     'register-statement' => 'Beköltözési nyilatkozat',
     'request' => 'Igénylés',
     'status-cert' => 'Tagsági igazolás',
+    'file_types' => [
+        'profile_picture' => 'Profilkép',
+        'receipt' => 'Számla',
+        'resume' => 'Önéletrajz',
+        'besorolasi_hatarozat' => 'Besorolási határozat',
+        'erettsegi' => 'Érettségi bizonyítvány',
+        'elvegzett_felev' => 'Igazolás az elvégzett félévekről',
+        'diploma' => 'Diploma',
+        'application_custom' => 'Egyéb dokumentumok, igazolások',
+    ]
 ];

--- a/resources/sass/materialize.scss
+++ b/resources/sass/materialize.scss
@@ -390,3 +390,7 @@ body.dark a.btn {
     width: 100%;
     text-align: center;
 }
+
+.form-disabled {
+    opacity: 0.5;
+}

--- a/resources/views/auth/admission/application.blade.php
+++ b/resources/views/auth/admission/application.blade.php
@@ -17,10 +17,11 @@
                 @csrf
                 <blockquote>Az új fájlról a felvételiztető bizottság tagjai értesítést kapnak.</blockquote>
                 <div class="row">
-                    <x-input.file s=12 m=6 id="file" accept=".pdf,.jpg,.png,.jpeg" text="general.browse"
+                    <x-input.file s=12 m=4 id="file" accept=".pdf,.jpg,.png,.jpeg" text="general.browse"
                                   helper=".pdf,.jpg,.png,.jpeg fájlok tölthetőek fel, maximum {{config('custom.general_file_size_limit')/1000}} MB-os méretig."
                                   required/>
-                    <x-input.text s=12 m=6 id="name" text="Fájl megnevezése" maxlength="250" required/>
+                    <x-input.select s=12 m=4 id="type" :elements="array_map(fn($type) => $type->value, \App\Enums\FileType::cases())"  :formatter="fn ($type) => __('document.file_types.' . $type, [], 'hu')" />
+                    <x-input.text s=12 m=4 id="name" text="Fájl megnevezése" maxlength="250" required/>
                 </div>
                 <x-input.button floating class="right" icon="upload"/>
             </div>

--- a/resources/views/auth/application/application.blade.php
+++ b/resources/views/auth/application/application.blade.php
@@ -269,7 +269,7 @@
                                 <td colspan="2">
                                     <p style="font-weight: bold;">Miért kíván a Collegium tagja lenni?</p>
                                     <p>
-                                        {{ $user->application->question_2 }}
+                                        <div style="white-space: pre-wrap">{{ $user->application->question_2 }}</div>
                                         @if(!$user->application->question_2)
                                             <span style="font-style:italic;color:red">hiányzó adat</span>
                                         @endif
@@ -283,7 +283,7 @@
                                         után?
                                         Milyen tervei vannak az egyetem után?</p>
                                     <p>
-                                        {{ $user->application->question_3}}
+                                        <div style="white-space: pre-wrap">{{ $user->application->question_3 }}</div>
                                         @if(!$user->application->question_3)
                                             <span style="font-style:italic;color:red">hiányzó adat</span>
                                         @endif
@@ -307,16 +307,12 @@
                                         <div class="row" style="margin-bottom: 0; padding: 10px">
                                             <div class="col" style="margin-top: 5px">
                                                 <a href="{{ url($file->path) }}"
-                                                   target="_blank">{{ $file->name }}</a>
+                                                   target="_blank">{{ $file->description }} ({{ __('document.file_types.' . $file->type->value, [], 'hu') }})</a>
                                             </div>
                                         </div>
                                     @empty
                                         <span style="font-style:italic;color:red">hiányzó adat</span>
                                     @endforelse
-                                    @if(count($user->application->files ?? []) > 0 && count($user->application->files ?? []) < 2)
-                                        <span
-                                            style="font-style:italic;color:red">legalább 2 fájlt fel kell tölteni</span>
-                                    @endif
                                 </td>
                             </tr>
                             <tr>

--- a/resources/views/auth/application/file_upload.blade.php
+++ b/resources/views/auth/application/file_upload.blade.php
@@ -70,7 +70,7 @@ $extensions = $extensions ?? '.pdf,.jpg,.png,.jpeg';
                         <x-input.file s=12 m=6 id="{{ 'file' . $type->value}}" name="file" accept="{{  $extensions }}" text="Fájl kiválasztása"
                             helper="{{  $extensions }} fájlok tölthetőek fel, maximum {{ config('custom.general_file_size_limit') / 1000 }} MB-os méretig."
                             required asterisk />
-                        <x-input.text s=12 m=4 id="{{ 'name' . $type->value }}" name="name" text="Fájl megnevezése" maxlength="250" required asterisk />
+                        <x-input.text s=12 m=4 id="{{ 'name' . $type->value }}" name="name" text="Fájl megnevezése" maxlength="250" required asterisk :value="$default_name ?? ''" />
                         <x-input.button id="{{ 'submit' . $type->value }}" class="s12 m2" only_input class="right" text="general.upload" />
                     </div>
                 </form>

--- a/resources/views/auth/application/file_upload.blade.php
+++ b/resources/views/auth/application/file_upload.blade.php
@@ -1,0 +1,80 @@
+<?php
+$active = $active ?? $application->needsFile($type);
+$optional = $optional ?? false;
+$files = $application->filesOfType($type)->get();
+?>
+<ul class="collapsible">
+    <li @class(['active' => $active, 'form-disabled' => !$active])>
+        <div class="collapsible-header">
+            @if (!$active)
+                <i class="material-icons">help_outline</i>
+            @elseif (count($files) > 0)
+                <i class="material-icons" style="color:green">check_circle</i>
+            @elseif (!$optional)
+                <i class="material-icons" style="color:red">cancel</i>
+            @else
+                <i class="material-icons" style="color:green">help_outline</i>
+            @endif
+            {{ __('document.file_types.' . $type->value, [], 'hu') }}
+        </div>
+        <div class="collapsible-body">
+            <div class="markdown_with_red">
+                @markdown(\App\Models\ConfigurableText::getText("APPLICATION_FILE_" . strtoupper($type->value)))
+            </div>
+
+
+            @if (!$active)
+            <hr />
+            <p style="font-style:italic;font-size:0.9em;color:black">A megadott tanulmányi adatok alapján ilyen típusú dokumentumot nem szükséges feltöltenie.</p>
+            @endif
+
+            @if ($active || count($files) > 0)
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Fájl megnevezése</th>
+                            <th>Letöltés</th>
+                            <th>Törlés</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($files as $file)
+                            <tr>
+                                <td>
+                                    <a href="{{ url($file->path) }}" target="_blank" style="text-decoration:underline">{{ $file->description }}</a>
+                                </td>
+                                <td>
+                                    <a href="{{ url($file->path) }}" class="btn-floating btn-small waves-effect waves-light coli" download>
+                                        <i class="material-icons">file_download</i>
+                                    </a>
+                                </td>
+                                <td>
+                                    <form method="POST"
+                                          action="{{ route('application.store', ['page' => 'files.delete', 'id' => $file->id]) }}"
+                                          enctype='multipart/form-data'>
+                                        @csrf
+                                        <x-input.button floating class="right btn-small red" icon="delete"/>
+                                    </form>
+                            </td>
+                            </tr>
+                        @endforeach
+                </table>
+            @endif
+
+            @if($active)
+                <form method="POST" action="{{ route('application.store', ['page' => 'files', 'type' => $type->value]) }}"
+                    enctype='multipart/form-data'>
+                    @csrf
+                    <div class="row" style="margin-top: 20px;">
+                        <x-input.file s=12 m=6 id="{{ 'file' . $type->value}}" name="file" accept=".pdf,.jpg,.png,.jpeg" text="Fájl kiválasztása"
+                            helper=".pdf,.jpg,.png,.jpeg fájlok tölthetőek fel, maximum {{ config('custom.general_file_size_limit') / 1000 }} MB-os méretig."
+                            required asterisk />
+                        <x-input.text s=12 m=4 id="{{ 'name' . $type->value }}" name="name" text="Fájl megnevezése" maxlength="250" required asterisk />
+                        <x-input.button id="{{ 'submit' . $type->value }}" class="s12 m2" only_input class="right" text="general.upload" />
+                    </div>
+                </form>
+            @endif
+
+        </div>
+    </li>
+</ul>

--- a/resources/views/auth/application/file_upload.blade.php
+++ b/resources/views/auth/application/file_upload.blade.php
@@ -2,6 +2,7 @@
 $active = $active ?? $application->needsFile($type);
 $optional = $optional ?? false;
 $files = $application->filesOfType($type)->get();
+$extensions = $extensions ?? '.pdf,.jpg,.png,.jpeg';
 ?>
 <ul class="collapsible">
     <li @class(['active' => $active, 'form-disabled' => !$active])>
@@ -66,8 +67,8 @@ $files = $application->filesOfType($type)->get();
                     enctype='multipart/form-data'>
                     @csrf
                     <div class="row" style="margin-top: 20px;">
-                        <x-input.file s=12 m=6 id="{{ 'file' . $type->value}}" name="file" accept=".pdf,.jpg,.png,.jpeg" text="Fájl kiválasztása"
-                            helper=".pdf,.jpg,.png,.jpeg fájlok tölthetőek fel, maximum {{ config('custom.general_file_size_limit') / 1000 }} MB-os méretig."
+                        <x-input.file s=12 m=6 id="{{ 'file' . $type->value}}" name="file" accept="{{  $extensions }}" text="Fájl kiválasztása"
+                            helper="{{  $extensions }} fájlok tölthetőek fel, maximum {{ config('custom.general_file_size_limit') / 1000 }} MB-os méretig."
                             required asterisk />
                         <x-input.text s=12 m=4 id="{{ 'name' . $type->value }}" name="name" text="Fájl megnevezése" maxlength="250" required asterisk />
                         <x-input.button id="{{ 'submit' . $type->value }}" class="s12 m2" only_input class="right" text="general.upload" />

--- a/resources/views/auth/application/files.blade.php
+++ b/resources/views/auth/application/files.blade.php
@@ -1,9 +1,6 @@
 @extends('auth.application.app')
 
 @section('form')
-    @include('utils.user.profile-picture', ['user' => $user])
-
-    {{-- uploaded files --}}
     <div class="card">
         <div class="card-content">
             <div class="card-title">Feltöltött fájlok</div>

--- a/resources/views/auth/application/files.blade.php
+++ b/resources/views/auth/application/files.blade.php
@@ -15,11 +15,13 @@
     @include('auth.application.file_upload', [
         'application' => $user->application,
         'type' => App\Enums\FileType::RESUME,
+        'extensions' => '.pdf',
     ])
 
     @include('auth.application.file_upload', [
         'application' => $user->application,
         'type' => App\Enums\FileType::BESOROLASI_HATAROZAT,
+        'extensions' => '.pdf',
     ])
 
     @include('auth.application.file_upload', [

--- a/resources/views/auth/application/files.blade.php
+++ b/resources/views/auth/application/files.blade.php
@@ -16,12 +16,14 @@
         'application' => $user->application,
         'type' => App\Enums\FileType::RESUME,
         'extensions' => '.pdf',
+        'default_name' => "Önéletrajz",
     ])
 
     @include('auth.application.file_upload', [
         'application' => $user->application,
         'type' => App\Enums\FileType::BESOROLASI_HATAROZAT,
         'extensions' => '.pdf',
+        'default_name' =>  "Besorolási határozat",
     ])
 
     @include('auth.application.file_upload', [

--- a/resources/views/auth/application/files.blade.php
+++ b/resources/views/auth/application/files.blade.php
@@ -1,7 +1,6 @@
 @extends('auth.application.app')
 
 @section('form')
-
     @include('utils.user.profile-picture', ['user' => $user])
 
     {{-- uploaded files --}}
@@ -10,43 +9,41 @@
             <div class="card-title">Feltöltött fájlok</div>
             <blockquote>
                 <div class="markdown_with_red">
-                    @markdown(\App\Models\ConfigurableText::getText("APPLICATION_FILES"))
+                    @markdown(\App\Models\ConfigurableText::getText('APPLICATION_FILES'))
                 </div>
             </blockquote>
-            <form method="POST" action="{{ route('application.store', ['page' => 'files']) }}"
-                  enctype='multipart/form-data'>
-                @csrf
-                <div class="row">
-                    <x-input.file s=12 m=6 id="file" accept=".pdf,.jpg,.png,.jpeg" text="Fájl kiválasztása"
-                        helper=".pdf,.jpg,.png,.jpeg fájlok tölthetőek fel, maximum {{config('custom.general_file_size_limit')/1000}} MB-os méretig." required
-                        asterisk
-                        />
-                    <x-input.text s=12 m=6 id="name" text="Fájl megnevezése" maxlength="250" required
-                        asterisk
-                    />
-                    <x-input.button only_input class="right" text="general.upload"/>
-                </div>
-            </form>
         </div>
     </div>
-    @forelse ($user->application->files ?? [] as $file)
-    <div class="card" style="padding: 10px 20px 10px 20px">
-        <div class="card-title">
-            <form method="POST"
-                  action="{{ route('application.store', ['page' => 'files.delete', 'id' => $file->id]) }}"
-                  enctype='multipart/form-data'>
-                @csrf
-                    <a href="{{ url($file->path) }}" target="_blank">{{ $file->name }}</a>
-                    <x-input.button floating class="right btn-small" icon="delete"/>
-            </form>
-        </div>
-    </div>
-    @empty
-    <div class="card" style="padding: 5px 20px 5px 20px">
-        <blockquote>
-            Még nem töltött fel egy fájlt sem.
-        </blockquote>
-    </div>
-    @endforelse
 
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::RESUME,
+    ])
+
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::BESOROLASI_HATAROZAT,
+    ])
+
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::ERETTSEGI,
+    ])
+
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::ELVEGZETT_FELEV,
+    ])
+
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::DIPLOMA,
+    ])
+
+    @include('auth.application.file_upload', [
+        'application' => $user->application,
+        'type' => App\Enums\FileType::APPLICATION_CUSTOM,
+        'active' => true,
+        'optional' => true,
+    ])
 @endsection

--- a/resources/views/auth/application/personal.blade.php
+++ b/resources/views/auth/application/personal.blade.php
@@ -2,6 +2,8 @@
 
 @section('form')
 
+    @include('utils.user.profile-picture', ['user' => $user])
+
     <div class="card">
         <div class="card-content">
             @include('user.personal-information', ['user' => $user, 'application' => true])

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -10,7 +10,7 @@
                     <x-input.text s=12 id="graduation_average" text="application.graduation_average" type='number' step="0.01" min="0"
                                   text="Érettségi átlaga" :value="$user->application->graduation_average"
                                   asterisk
-                                  helper='Az összes érettségi tárgy hagyományos átlaga'/>
+                                  helper='Az összes érettségi tárgy százalékos eredményének hagyományos átlaga'/>
                     <div class="col s12">
                         @livewire('parent-child-form', [
                         'title' => "Van lezárt egyetemi félévem",
@@ -121,7 +121,7 @@
                         </div>
                     </div>
                     <div>
-                        <label for="question_2" style="font-size: 15px;color:black">Miért kíván a Collegium tagja lenni? (≈300-500 karakter) <span style="color:red;" aria-label="required">*</span></label>
+                        <label for="question_2" style="font-size: 15px;color:black">Miért kíván a Collegium tagja lenni? (≈500-1000 leütés) <span style="color:red;" aria-label="required">*</span></label>
                         <x-input.textarea id="question_2"
                                         :value="$user->application->question_2"
                                         style="min-height:200px"

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -180,20 +180,40 @@
 @endsection
 
 @push('scripts')
-<script>
-    const handlePseudonymVisibility = () => {
-        const pseudonymWrapper = document.getElementById('pseudonym-wrapper');
-        const publicationConsent = document.querySelector('input[name="publication_consent"]');
-        if (!publicationConsent.checked) {
-            pseudonymWrapper.style.display = 'block';
-        } else {
-            pseudonymWrapper.style.display = 'none';
+    <script>
+        const handlePseudonymVisibility = () => {
+            const pseudonymWrapper = document.getElementById('pseudonym-wrapper');
+            const publicationConsent = document.querySelector('input[name="publication_consent"]');
+            if (!publicationConsent.checked) {
+                pseudonymWrapper.style.display = 'block';
+            } else {
+                pseudonymWrapper.style.display = 'none';
+            }
         }
-    }
 
-    document.addEventListener('DOMContentLoaded', () => {
-        handlePseudonymVisibility();
-        document.querySelector('input[name="publication_consent"]').addEventListener('change', handlePseudonymVisibility);
-    });
-</script>
+        document.addEventListener('DOMContentLoaded', () => {
+            handlePseudonymVisibility();
+            document.querySelector('input[name="publication_consent"]').addEventListener('change', handlePseudonymVisibility);
+        });
+
+        document.addEventListener('DOMContentLoaded', () => {
+            let textIsDirty = false;
+            document.querySelectorAll('textarea').forEach(
+                (textarea) => textarea.addEventListener('input', () => {
+                    textIsDirty = true;
+                })
+            );
+
+            document.querySelector('button[type="submit"]').addEventListener('click', () => {
+                textIsDirty = false;
+            });
+
+            window.addEventListener('beforeunload', (event) => {
+                if (textIsDirty) {
+                    event.preventDefault();
+                    event.returnValue = '';
+                }
+            });
+        });
+    </script>
 @endpush

--- a/resources/views/user/educational-information.blade.php
+++ b/resources/views/user/educational-information.blade.php
@@ -102,7 +102,7 @@
             </div>
         @endif
     </div>
-    <p style="margin-bottom:10px">Szakok: <span style="color:red;" aria-label="required">*</span></p>
+    <p style="margin-bottom:10px">Szakok (összes korábbi és aktuális egyaránt): <span style="color:red;" aria-label="required">*</span></p>
     @foreach($user->educationalInformation?->studyLines ?? [] as $studyLine)
         @include('user.study-line-selector', ['index' => $loop->index, 'value' => $studyLine])
     @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,7 +94,8 @@ Route::middleware([Authenticate::class, LogRequests::class])->group(function () 
     /** Routes that needs to be accessed during the application process */
     Route::get('/application', [ApplicationController::class, 'show'])
         ->name('application')
-        ->withoutMiddleware(RedirectTenantsToUpdate::class);
+        ->withoutMiddleware(RedirectTenantsToUpdate::class)
+        ->middleware(OnlyHungarian::class);
     Route::post('/application/confirm_start', [ApplicationController::class, 'confirmStart'])
         ->name('application.confirm_start')
         ->withoutMiddleware(RedirectTenantsToUpdate::class);


### PR DESCRIPTION
- Introduce a type enum in the files table
- Add a dedicated section in the UI for each required document type
- Add validation rules that check if each required document type was
  provided

The description texts in the UI can be changed via the configurable
texts framework without re-deploying the code.

Work towards #742

Sorry for the painful Hunglish, but I'm not going to try to translate the official document type names to English.