### PR TITLE
Add elaborated information on how to obtain the training code

### DIFF
--- a/app/View/Components/Input/Text.php
+++ b/app/View/Components/Input/Text.php
@@ -7,19 +7,22 @@ use App\View\Components\Input;
 class Text extends Input
 {
     public $helper;
+    public $elaboratedHelper;
     public $withoutLabel;
 
     /**
      * Create a new text input instance.
      *
      * @param  string  $helper  helper message
+     * @param  ?string $elaboratedHelper elaborated helper message
      * @param  ?string $value   pre-filled contents
      * @return void
      */
-    public function __construct($id, $withoutLabel = false, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $helper = null, ?string $value = '')
+    public function __construct($id, $withoutLabel = false, $text = null, $s = 12, $m = null, $l = null, $xl = null, $onlyInput = false, $helper = null, ?string $value = '', $elaboratedHelper = null)
     {
         parent::__construct($id, $text, $s, $m, $l, $xl, $onlyInput);
         $this->helper = $helper;
+        $this->elaboratedHelper = $elaboratedHelper;
         $this->withoutLabel = $withoutLabel;
         $this->value = $value;
     }

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -19,7 +19,12 @@
     </label>
     @endif
     @if($helper ?? null)
-    <span class="helper-text">{{ $helper }}</span>
+        <span class="helper-text">
+            {{ $helper }}
+            @if ($elaboratedHelper)
+                <i class="material-icons tooltipped" style="font-size: 1.25em; vertical-align: -0.2em; cursor: default" data-tooltip="{{ $elaboratedHelper }}">info_outline</i>
+            @endif
+        </span>
     @endif
     @error($id)
         <span class="helper-text" data-error="{{ $message }}"></span>

--- a/resources/views/user/study-line-selector.blade.php
+++ b/resources/views/user/study-line-selector.blade.php
@@ -25,6 +25,7 @@
                     :value="$value?->training_code"
                     :required="$user->isCollegist(alumni: true)"
                     helper="Pl. TTK-FIZIKA-NBHU"
+                    elaborated-helper="A Neptunban belépést követően a legfelső sávban található."
                     asterisk
                     :disabled="user()->cannot('edit', $user)"
                     maxlength="255"


### PR DESCRIPTION
The text is too long to conveniently fit in the regular helper text, let's put it behind an "info" icon.

<img width="848" height="292" alt="image" src="https://github.com/user-attachments/assets/59917e13-9339-4f14-bf65-8e2000c0497b" />
