### PR TITLE
Pre-fill averages for two semesters

### DIFF
--- a/app/Livewire/ParentChildForm.php
+++ b/app/Livewire/ParentChildForm.php
@@ -16,6 +16,7 @@ class ParentChildForm extends Component
     public $hidden; // hidden state
     public $optional; // if true, the form is hidden by default (meaning no data is given), and a checkbox is added whether the user wants to add data or not
     public $inputAttributes = ['type' => 'text']; // attributes for the input field, can be overridden by the caller
+    public $default_value = [''];
 
     /**
      * Mount the component.
@@ -28,8 +29,12 @@ class ParentChildForm extends Component
         if (is_null($items) || count($items) == 0) {
             $items = [''];
         }
-        $this->items = old($this->name) ?? $items;
-        $this->hidden = $optional ? count($this->items) == 1 && $this->items[0] == '' : false;
+        $this->hidden = $optional ? count($items) == 1 && $items[0] == '' : false;
+
+        if (count($items) == 1 && $items[0] == '') {
+            $items = $this->default_value;
+        }
+        $this->items = $items;
         $this->optional = $optional;
     }
 

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -17,7 +17,8 @@
                         'name' => 'semester_average',
                         'helper' => 'Hagyományos átlag a félév(ek)ben (két tizedesjegyre kerekítve)',
                         'optional' => true,
-                        'items' => empty($user->application->semester_average) ? [null, null] : $user->application->semester_average,
+                        'items' => $user->application->semester_average,
+                        'default_value' => [null, null], 
                         'inputAttributes' => ['type' => 'number', 'step' => '0.01', 'min' => '0']])
                     </div>
                     <div class="col s12">

--- a/resources/views/auth/application/questions.blade.php
+++ b/resources/views/auth/application/questions.blade.php
@@ -17,7 +17,7 @@
                         'name' => 'semester_average',
                         'helper' => 'Hagyományos átlag a félév(ek)ben (két tizedesjegyre kerekítve)',
                         'optional' => true,
-                        'items' => $user->application->semester_average,
+                        'items' => empty($user->application->semester_average) ? [null, null] : $user->application->semester_average,
                         'inputAttributes' => ['type' => 'number', 'step' => '0.01', 'min' => '0']])
                     </div>
                     <div class="col s12">


### PR DESCRIPTION
By creating two input boxes when the user selects the "I have previous finished semesters" check box, we can avoid people creating a single entry by taking the average across all semesters.

Obligatory "this is a hack".
