### PR TITLE
Harmonize profile picture UI on profile page and applicants view

### DIFF
--- a/resources/views/auth/application/application.blade.php
+++ b/resources/views/auth/application/application.blade.php
@@ -12,7 +12,7 @@
                             @endif
                             >
                         @else
-                            <span style="font-style:italic;color:red"
+                            <span style="font-style:italic"
                             @if ($user->id != user()->id)
                                 class="hideable-picture"
                             @endif>Nincs profilkép.</span>

--- a/resources/views/utils/user/profile-picture.blade.php
+++ b/resources/views/utils/user/profile-picture.blade.php
@@ -1,8 +1,12 @@
 {{-- desktop profile pic --}}
 <div class="card horizontal hide-on-med-and-down">
     <div class="card-image">
+        @if (isset($user->application) && !isset($user->profilePicture))
+            <p style="font-style:italic;width:300px;text-align:center">Nincs profilkép.</p>
+        @else
         <img src="{{ url($user->profilePicture ? $user->profilePicture->path : '/img/avatar.png') }}"
                 style="max-width:300px; max-height:500px;">
+        @endif
     </div>
     <div class="card-stacked">
         <div class="card-content">
@@ -40,7 +44,12 @@
 {{-- mobile profile pic --}}
 <div class="card hide-on-large-only">
     <div class="card-image" >
-        <img style="max-height: 500px; object-fit: contain;" src="{{ url($user->profilePicture ? $user->profilePicture->path : '/img/avatar.png') }}">
+        @if (isset($user->application) && !isset($user->profilePicture))
+            <p style="font-style:italic;width:100%;text-align:center">Nincs profilkép.</p>
+        @else
+        <img src="{{ url($user->profilePicture ? $user->profilePicture->path : '/img/avatar.png') }}"
+                style="max-height: 500px; object-fit: contain;">
+        @endif
     </div>
         <div class="card-content">
             <div class="card-title">{{$user->name}}</div>


### PR DESCRIPTION
Let's denote the lack of profile picture by a "Nincs profilkép." text when filling out when filling out the application form, similarly to what's shown on the admissions index page.

<img width="988" height="311" alt="image" src="https://github.com/user-attachments/assets/c1d2b939-1fb3-441c-a5e8-34cd6227b300" />

This commit also removes the red font color for missing profile pictures to annoy application committee members less.