### PR TITLE
De-duplicate available workshops on /applicants

### DIFF
--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -138,7 +138,7 @@ class ApplicationPolicy
     public static function getAccessibleWorkshops(User $user): Collection
     {
         if ($user->cannot('viewAll', Application::class)) {
-            return $user->roleWorkshops->concat($user->applicationCommitteWorkshops);
+            return $user->roleWorkshops->merge($user->applicationCommitteWorkshops);
         }
         return Workshop::all();
     }


### PR DESCRIPTION
Without this change, if a user is both an administrator for a workshop and has an application committee role for it, the workshop's name would show up twice in the workshop chooser dropdown.

Reported by Tóth Fanni.
