### PR TITLE
Tiny quality-of-life fixes for applications

### DIFF
--- a/resources/js/materialize_custom.js
+++ b/resources/js/materialize_custom.js
@@ -12156,7 +12156,8 @@ $jscomp.polyfill = function (e, r, p, m) {
           this.options.dropdownOptions.autoFocus = false; 
 
           var placeholder = this.el.getAttribute('searchable');
-          var element = $('<div class="input-field col s12"><input type="text" class="dropDownsearch" style="margin: 5px 0px 16px 15px; width: 96%;"> <label for="first_name">'+ placeholder + '</label></div>');
+          var randomId = M.guid();
+          var element = $(`<div class="input-field col s12"><input type="text" id="search-${randomId}" class="dropDownsearch" style="margin: 5px 0px 16px 15px; width: 96%;"> <label for="search-${randomId}">${placeholder}</label></div>`);
           $(this.dropdownOptions).append(element);
           element.children().first().on('keyup', function(event){
             applySeachInList(this.value);

--- a/resources/views/auth/application/app.blade.php
+++ b/resources/views/auth/application/app.blade.php
@@ -57,7 +57,7 @@
             <ul class="tabs tabs-transparent" style="display: flex; flex-wrap: wrap; height: auto;">
                 <li class="tab">
                     <a href="{{ route('application', ['page' => 'personal']) }}"
-                        class="{{ request()->get('page') == 'personal' ? 'active' : '' }}">Személyes adatok</a>
+                        class="{{ request()->get('page', 'personal') == 'personal' ? 'active' : '' }}">Személyes adatok</a>
                 </li>
                 <li class="tab">
                     <a href="{{ route('application', ['page' => 'educational']) }}"

--- a/resources/views/user/personal-information.blade.php
+++ b/resources/views/user/personal-information.blade.php
@@ -24,6 +24,7 @@
         @endif
         <x-input.text
             id="name"
+            autocomplete="name"
             text="user.full_name"
             :value="$user->name"
             required
@@ -34,6 +35,7 @@
         <x-input.text
             id="email"
             type="email"
+            autocomplete="email"
             text="user.email"
             :value="$user->email"
             required
@@ -77,6 +79,7 @@
         <x-input.text
             id='phone_number'
             type='tel'
+            autocomplete='tel'
             pattern="[+][0-9]{1,4}[-\s()0-9]*"
             minlength="8"
             maxlength="18"
@@ -101,6 +104,7 @@
             />
         <x-input.text
             l=6 id='county'
+            autocomplete='address-level1'
             text='user.county'
             required
             :value="$user->personalInformation?->county"
@@ -112,6 +116,7 @@
         <x-input.text
             l=6
             id='zip_code'
+            autocomplete='postal-code'
             text='user.zip_code'
             :value="$user->personalInformation?->zip_code"
             :required="$user->isCollegist()"
@@ -121,6 +126,7 @@
             />
         <x-input.text
             id='city'
+            autocomplete='address-level2'
             text='user.city'
             :value="$user->personalInformation?->city"
             :required="$user->isCollegist()"
@@ -130,6 +136,7 @@
         />
         <x-input.text
             id='street_and_number'
+            autocomplete='street-address'
             text='user.street_and_number'
             :value="$user->personalInformation?->street_and_number"
             :required="$user->isCollegist()"


### PR DESCRIPTION
See the individual commits:

### Make the "Keresés..." label clickable in dropdowns

The label didn't have the `for` attribute set, so clicking on it didn't focus the input field.

### Support autocomplete for personal information fields

### Fix tab highlight for initially open applications

When first opening the applications page, the `page` query parameter is not set. In this case, the personal information tab is displayed. Make it highlighted by default.
