### PR TITLE
Add VSCode extensions to the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,21 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"php-cs-fixer.executablePath": "${workspaceFolder}/vendor/bin/php-cs-fixer"
+				"php-cs-fixer.executablePath": "/workspace/mars/vendor/bin/php-cs-fixer",
+				"editor.formatOnSave": true,
+				"editor.formatOnSaveMode": "modifications",
+				"[php]": {
+					"editor.defaultFormatter": "junstyle.php-cs-fixer"
+				},
+				"cSpell.language": "en,hu"
 			},
 			"extensions": [
-				"junstyle.php-cs-fixer"
+				"bmewburn.vscode-intelephense-client",
+				"graphql.vscode-graphql-syntax",
+				"junstyle.php-cs-fixer",
+				"laravel.vscode-laravel",
+				"streetsidesoftware.code-spell-checker",
+				"streetsidesoftware.code-spell-checker-hungarian"
 			]
 		}
 	},


### PR DESCRIPTION
The following extensions will be automatically installed in the container:
- PHP Intelephense: tab completion and go-to-definition provider for PHP
- Laravel: Blade syntax highlighting, code completion for auto-generated methods in Eloquent models
- php cs fixer: automatic formatting that matching the style expected by CI
- GraphQL Syntax Highlighting
- Code Spell Checker + Hungarian dictionary
