### PR TITLE
Support sending e-mails via Caesar

### DIFF
--- a/app/Mail/CaesarProxyTransport.php
+++ b/app/Mail/CaesarProxyTransport.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mail;
+
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\MessageConverter;
+
+class CaesarProxyTransport extends AbstractTransport
+{
+    private string $proxyUrl;
+    private string $secretKey;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->proxyUrl = config('mail.mail_proxy_url');
+        $this->secretKey = base64_decode(config('mail.mail_proxy_secret'));
+    }
+
+    protected function doSend(SentMessage $sentMessage): void
+    {
+        $email = MessageConverter::toEmail($sentMessage->getOriginalMessage());
+
+        $headers = $email->getPreparedHeaders();
+        $headers->remove('To');
+        $headers->remove('Subject');
+
+        $bcc = implode("\r\n", array_map(fn (Address $addr) => 'Bcc: ' . $addr->toString(), $email->getBcc()));
+        if ($bcc) {
+            $bcc .= "\r\n";
+        }
+
+        $data = json_encode([
+            'to' => implode(',', array_map(fn (Address $addr) => $addr->toString(), $email->getTo())),
+            'subject' => $email->getSubject(),
+            'message' => $email->getBody()->bodyToString(),
+            'headers' => $headers->toString() . $bcc . $email->getBody()->getPreparedHeaders()->toString(),
+        ]);
+
+        $signature = hash_hmac('sha256', $data, $this->secretKey);
+
+        $options = [
+            'http' => [
+                'header'  => "Content-Type: application/json\r\n" .
+                             "X-Signature: $signature\r\n",
+                'method'  => 'POST',
+                'content' => $data,
+            ],
+        ];
+
+        $context  = stream_context_create($options);
+        $success = file_get_contents($this->proxyUrl, false, $context);
+
+        if ($success === false) {
+            throw new \Exception('Failed to send email via Caesar Proxy Transport: ' . print_r(error_get_last(), true));
+        }
+    }
+
+    public function __toString(): string
+    {
+        return 'caesar-proxy';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,9 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Route;
 use App\Models\User;
+use App\Mail\CaesarProxyTransport;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -56,6 +58,10 @@ class AppServiceProvider extends ServiceProvider
 
         // Throw error when trying to access an attribute that does not exist.
         Model::preventAccessingMissingAttributes(config('app.preventAccessingMissingAttributes'));
+
+        Mail::extend('caesar-proxy', function () {
+            return new CaesarProxyTransport();
+        });
 
         $this->loadGoogleStorageDriver('google');
         $this->loadGoogleStorageDriver('google_admin');

--- a/config/mail.php
+++ b/config/mail.php
@@ -12,6 +12,9 @@ return [
     'secretary_mail' => env('MAIL_SECRETARY'),
     'membra_mail' => env('MAIL_MEMBRA'),
 
+    'mail_proxy_secret' => env('MAIL_PROXY_SECRET'),
+    'mail_proxy_url' => env('MAIL_PROXY_URL'),
+
     /*
     |--------------------------------------------------------------------------
     | Mail Driver


### PR DESCRIPTION
Google no longer allows us to send Urán automated e-mails through the ejcroot@gmail.com personal Google account, as we get quota exceeded failures even if we send fewer emails than the limit.

This commit introduces a custom transport driver which forwards the emails to Caesar through HTTP, which can then use PHP's `mail()` function to send from the base.elte.hu domain.

To use this, set `MAIL_MAILER` to `caesar-proxy` in .env and specify `MAIL_PROXY_SECRET` and `MAIL_PROXY_URL`.

