### PR TITLE
Making the commenting instructions more explicit about e-mail notifications

### DIFF
--- a/resources/views/auth/admission/application.blade.php
+++ b/resources/views/auth/admission/application.blade.php
@@ -38,7 +38,7 @@
                     @csrf
                     <div class="col">
                         <blockquote>A megjegyzéseket a felvételiző nem látja, de azok láthatóak a többi felvételiztető számára (akár más műhelyekből is).<br/>
-                            A módosításokról a felvételiztető bizottság tagjai értesítést kapnak.</blockquote>
+                            <i>Csak akkor írj ide</i>, ha szeretnéd, hogy <i>minden</i> releváns felvételiztető e-mailt kapjon a megjegyzésről!</blockquote>
                     </div>
                     <x-input.textarea id="note"
                                       text="Megjegyzés"


### PR DESCRIPTION
There were some misunderstandings last time; maybe this helps.

<img width="1161" height="332" alt="grafik" src="https://github.com/user-attachments/assets/0dcce48d-2592-4180-9b7b-8c2eb4c3d3e1" />
